### PR TITLE
Feature/nicenewlines

### DIFF
--- a/module1/coursinternet.md
+++ b/module1/coursinternet.md
@@ -64,10 +64,10 @@ développer dans ces cours.
 etc, par des nombres dans un ordinateur ?</p>
 {
 ~<p>C'est un choix industriel.</p>#<p>Non, les industriels n'avaient pas le choix.</p>
-~<p>Les ordinateurs ont été inventés par des mathématiciens.</p>#<p>Non, les mathématiciens savent manipuler autre chose que des nombres, et les ordinateurs sont le fruit de l'interaction entre de nombreuses sciences.</p> 
+~<p>Les ordinateurs ont été inventés par des mathématiciens.</p>#<p>Non, les mathématiciens savent manipuler autre chose que des nombres, et les ordinateurs sont le fruit de l'interaction entre de nombreuses sciences.</p>
 =<p>Tout ordinateur est fondamentalement une machine qui calcule avec des
 nombres.</p>#<p>Oui, comme un ordinateur ne manipule que des nombres,
-tout doit être représenté sous forme de nombres être manipulé par un ordinateur.</p> 
+tout doit être représenté sous forme de nombres être manipulé par un ordinateur.</p>
 ####<p>Un ordinateur ne manipule que des nombres, tout doit donc être représenté sous forme de nombres pour qu'il puisse le manipuler.</p> }
 
 ::Numérisation::
@@ -87,32 +87,38 @@ ces objets sont équipés de micro-processeurs !</p> }
 ```
 
 ```activité
-::Le numérique concerne tout le monde:: 
+::Le numérique concerne tout le monde::
 [markdown]
 **Quels étudiants sont concernés par le numérique ?**
+\n
 Le numérique concerne évidemment les étudiants en informatique et plus généralement les étudiants des filières scientifiques.  Mais vous qui êtes inscrits dans une université de sciences humaines et sociales, êtes-vous concernés ?
+\n
 Choisissez au moins 3 des domaines suivants et faites des recherches pour voir en quoi ils sont impactés par le numérique : les médias, la santé, l'histoire, la sociologie, la linguistique, les arts, la culture, l'enseignement, l'archéologie.
+\n
 Faites une synthèse en quelques lignes de vos recherches en précisant les domaines auxquels vous vous êtes intéressés. Indiquez les liens des sites sur lesquels vous avez trouvé ces informations. La liste est non exhaustive et vous pouvez vous intéresser à d'autres domaines.
-{#### 
+{####
 # Le numérique concerne tout le monde
 Ces recherches ont dû vous convaincre, si c'était nécessaire, que le numérique **n'est pas réservé** aux informaticiens, il concerne tout le monde, toutes les disciplines.
-S'agissant plus particulièrement des **sciences humaines**, la prise en compte du numérique a fait évoluer les champs disciplinaires pour faire apparaître ce qu'on appelle les **humanités numériques** ( *digital humanities* en anglais). 
+S'agissant plus particulièrement des **sciences humaines**, la prise en compte du numérique a fait évoluer les champs disciplinaires pour faire apparaître ce qu'on appelle les **humanités numériques** ( *digital humanities* en anglais).
+\n
 Voici quelques exemples que nous vous proposons, n'hésitez pas à proposer d'autres exemples dans le forum de discussion :
+\n
 * Dans les **médias** : nouveau sous-métier de journalisme : les **data-journalistes**
- * [data-visualisation](http://www.lemonde.fr/data-visualisation/)
- * [journalisme de données](http://fr.wikipedia.org/wiki/Journalisme_de_données)
+	* [data-visualisation](http://www.lemonde.fr/data-visualisation/)
+	* [journalisme de données](http://fr.wikipedia.org/wiki/Journalisme_de_données)
 * Dans la **santé** : (imagerie, dossier numérique du patient, ...)
-  * [simulation](https://interstices.info/jcms/c_21525/simulation-de-loperation-de-la-cataracte)
+	* [simulation](https://interstices.info/jcms/c_21525/simulation-de-loperation-de-la-cataracte)
 * En **histoire, sociologie, linguistique** : *fouille de données*
-   * [fouille de données](http://www.youtube.com/watch?feature=player_embedded&v=tp4y-_VoXdA)
+	* [fouille de données](http://www.youtube.com/watch?feature=player_embedded&v=tp4y-_VoXdA)
 * En **art et culture** :
 	* [Le Fresnoy](http://www.lefresnoy.net/fr/Le-Fresnoy/presentation)
-* Dans l'**enseignement** : (outils numérique d'accompagnement scolaire, MOOC,...)
-   * [FUN](https://www.france-universite-numerique-mooc.fr/cours/)
-* En fouille archéologique :  une réalisation prestigieuse réalisée à Lille3 : 
- * [vase qui parle]http://bsa.biblio.univ-lille3.fr/blog/2013/09/exposition-le-vase-qui-parle-au-palais-des-beaux-arts-de-lille/)}
+* Dans l'**enseignement** : (outils numérique d'accompagnement scolaire, MOOC,...):
+	* [FUN](https://www.france-universite-numerique-mooc.fr/cours/)
+* En fouille archéologique :  une réalisation prestigieuse réalisée à Lille3 :
+	* [vase qui parle](http://bsa.biblio.univ-lille3.fr/blog/2013/09/exposition-le-vase-qui-parle-au-palais-des-beaux-arts-de-lille/)
+}
 ```
- 
+
 ```activité-avancée
 ::Le numérique au quotidien::[markdown]Les microprocesseurs, les ordinateurs ont envahi notre quotidien. Pour chacun des domaines suivants, cherchez des exemples où le numérique a permis des évolutions notables :
 \n
@@ -122,16 +128,22 @@ Voici quelques exemples que nous vous proposons, n'hésitez pas à proposer d'au
 - Médical / paramédical
 \n
 Après avoir effectué vos recherches, copier dans la fenêtre de rendu 1 lien pour au moins 3 des 4 thèmes proposés (un lien par thème).
-{#### 
+{####
 # le numérique au quotidien
 Quelques exemples que nous vous proposons au cas où vous n'auriez rien trouvé, ...
+\n
 La **domotique** est un domaine en pleine expansion qui vise à équiper numériquement notre maison :
+\n
 - [nest](https://nest.com/fr/)
 - [domotique](http://fr.wikipedia.org/wiki/Domotique)
+\n
 Pour les **transports**, les ordinateurs de bord sont depuis longtemps présents dans les voitures, de plus en plus ils sont responsables de notre sécurité :
+\n
 - [electrostabilisateur]( http://fr.wikipedia.org/wiki/electrostabilisateur_programmé)
 - [ordinateur de bord](http://fr.wikipedia.org/wiki/Ordinateur_de_bord)
+\n
 Les **chaussures** : gadget ou réelle innovation ? Ce genre d'objet est de plus en plus présents dans nos vies :
+\n
  - [chaussures](http://www.linternaute.com/science/technologie/deja-demain/07/chaussure-intelligente/chaussure-intelligente.shtml)
 Les **lentilles pour la vue** ?
  - [lentilles](http://www.zdnet.fr/actualites/google-apres-les-lunettes-connectees-les-lentilles-pour-le-diabete-39797148.htm)
@@ -140,20 +152,24 @@ Les **lentilles pour la vue** ?
 ::Le numérique dans la société::
 [markdown]
 **Le numérique, un enjeu pour les citoyens du XXIème siècle** ...
+\n
 Le numérique nous concerne tous en tant que citoyen. Il permet de nouvelles choses en automatisant des procédures et en donnant accès à des données jusqu'ici inexploitables. Mais numérique n'est évidemment pas systématiquement synonyme de progrès. Il faut toujours réfléchir aux **finalités des applications** développées. Nous vous invitons à vous documenter et à réfléchir aux questions suivantes :
- - Dans la **gestion de l‘énergie**: qu'est-ce que la troisième révolution industrielle et pourquoi le numérique y contribue-t-il ?
+\n
+- Dans la **gestion de l‘énergie**: qu'est-ce que la troisième révolution industrielle et pourquoi le numérique y contribue-t-il ?
 - En **politique et média** : Qu'est-ce que la vérification par les faits (fact-checking en anglais) ? En quoi le numérique l'a rendue possible / facile ?
 - En **citoyenneté** : Que signifie vote électronique et en quoi cela pose-t-il des questions essentielles ? Trouver au moins un avantage et un inconvénient.
+\n
 Après avoir fait vos recherches, répondez aux questions posées en quelques lignes et en indiquant les liens où vous avez trouvé ces informations.
 {####
 Voici quelques liens que nous vous proposons mais que vous avez sûrement trouvés par vous-même :
+\n
 - À propos de la troisième révolution industrielle :
-  - [Troisième révolution industrielle](http://fr.wikipedia.org/wiki/Troisième_révolution_industrielle)
-  - [pasdecalais](http://www.latroisiemerevolutionindustrielleennordpasdecalais.fr)
+	- [Troisième révolution industrielle](http://fr.wikipedia.org/wiki/Troisième_révolution_industrielle)
+	- [pasdecalais](http://www.latroisiemerevolutionindustrielleennordpasdecalais.fr)
 - En politique et média : Qu'est-ce que la vérification par les faits (fact-checking en anglais) ? En quoi le numérique l'a rendue possible / facile ?
-  - [vérification par les faits](http://fr.wikipedia.org/wiki/Vérification_par_les_faits)
+	- [vérification par les faits](http://fr.wikipedia.org/wiki/Vérification_par_les_faits)
 - En citoyenneté : Que signifie vote électronique et en quoi cela pose-t-il des questions essentielles ? Trouver au moins un avantage et un inconvénient.
-  - [arguments] (http://fr.wikipedia.org/wiki/Vote_électronique#Arguments_en_faveur)
+	- [arguments] (http://fr.wikipedia.org/wiki/Vote_électronique#Arguments_en_faveur)
 }
 ```
 
@@ -231,27 +247,34 @@ puissant au même prix.
 ```Activité
 ::La puissance augmente::
 [markdown]**Une histoire de puissance**
+\n
 Entre mon ordinateur et l'ordinateur de mon père qui ont 12 ans d'écart, quelle est la différence de puissance à laquelle on peut s'attendre ? Pensez à utiliser la loi de Moore et pensez à bien écrire la puissance après 2ans, 4 ans, 6 ans, ..., avant de répondre.
 {
 ~Ils sont tous les deux aussi puissants, ça n'a pas changé en 12 ans.#Il faut revoir la vidéo !
 ~Mon ordinateur est environ 20 fois plus puissant.#Bien plus que ça...
 =Mon ordinateur est environ 60 fois plus puissant#Tout à fait !
 ~Mon ordinateur est environ 150 fois plus puissant.#Quand même pas tant que ça !
-####2 ans : x 2
-4 ans : x 4
-6 ans : x 8
-8 ans : x16
-10 ans : x32
-12 ans : x64
-En d'autres mots un traitement qui prenait 30 min avec l'ordinateur de mon père s'effectue en 28 s sur le mien !}
+####[markdown]Réponse:
+\n
+	- 2 ans : x 2
+	- 4 ans : x 4
+	- 6 ans : x 8
+	- 8 ans : x16
+	- 10 ans : x32
+	- 12 ans : x64
+\n
+En d'autres mots un traitement qui prenait 30 min avec l'ordinateur de mon père s'effectue en 28 s sur le mien !
+}
+
 
 ::Un bug::
 [markdown]**D'où vient le mot "bug" ?**
+\n
 Il est malheureusement courant d'être confronté à des programmes <em>bugués</em>, c'est à dire des programmes qui ne font pas ce qu'ils sont sensés faire. Mais savez-vous d'où vient le terme *bug* ?
 {
 =En anglais, bug signifie insecte. Un insecte s'était glissé dans le mécanisme d'un des premiers ordinateurs, ce qui avait fait griller un relais et provoqué une panne.#En effet, il s'agissait d'une mite.
-~Bug était le surnom d'un des premiers programmeurs chez Microsoft, il était réputé pour commettre beaucoup d'erreurs.#Non, cherchez bien, c'est sur le web ! 
-~Bug est la version en verlan de GUB (Grande Unité Binaire), un projet d'ordinateur qui n'a jamais fonctionné.#Non, cherchez bien, c'est sur le web ! 
+~Bug était le surnom d'un des premiers programmeurs chez Microsoft, il était réputé pour commettre beaucoup d'erreurs.#Non, cherchez bien, c'est sur le web !
+~Bug est la version en verlan de GUB (Grande Unité Binaire), un projet d'ordinateur qui n'a jamais fonctionné.#Non, cherchez bien, c'est sur le web !
 ~Bug est le diminutif de Bugatti, la marque de la première voiture de luxe de Bill Gates, le fondateur de Microsoft. Cette voiture serait tombée 13 fois en panne en un an...#Non, cherchez bien, c'est sur le web !
 ~L'équipe des fondateurs d'Apple étaient des fans du dessin animé Bugs Bunny. Ils avaient pris l'habitude d'appeler Bugs leurs erreurs de programmation.#Non, cherchez bien, c'est sur le web !
 ####Le premier bug a été causé par [une mite](media/TheFirstBug_1947.jpg)
@@ -260,119 +283,180 @@ Il est malheureusement courant d'être confronté à des programmes <em>bugués<
 
 ```activite-avancee
 ::Des personnages importants::
-[markdown]**Des personnages importants**
+[markdown]
 Tout ne s'est pas fait en un jour, ...
+\n
 Vous connaissez sans doute des personnages importants de l'activité économique liée à l'informatique. Mais de nombreux chercheurs et ingénieurs ont contribué au développement des idées et des machines. Nous vous proposons de faire une recherche sur 4 personnes, dont 2 femmes qui ont largement contribué, chacune à leur façon,  à l'essor de l'informatique :
+\n
 - [Ada Lovelace](http://fr.wikipedia.org/wiki/Ada_Lovelace)
 - [Grace Hopper](http://fr.wikipedia.org/wiki/Grace_Hopper)
 - [Alan Turing](http://fr.wikipedia.org/wiki/Alan_Turing)
 - [John Von Neuman](http://fr.wikipedia.org/wiki/John_von_Neumann)
+\n
 Par ailleurs, l'un de ces personnages est étroitement lié à une machine : **ENIGMA**. Vous chercherez également ce qu'est cette machine et à quoi elle servait. Tous deux, l'homme et la machine, sont les héros du film *The imitation Game* sorti sur les écrans français en janvier 2015.
+\n
 Après avoir effectué vos recherches sur ces personnes et cette machine, rédigez une présentation en quelques lignes en les resituant chronologiquement.
 {####
 ## Personnages importants
 ### Ada Lovelace
 ![Ada Lovelace](media/adalovelace.jpg)
+\n
 *Ada Lovelace* est une **mathématicienne**, fille du poète Lord Byron qui travaille au milieu du **XIXeme** avec Charles **Babbage** sur un projet que nous pourrions qualifier de **premier ordinateur**.
+\n
 Ce projet n'aboutira finalement pas dans un succès commercial mais aura contribué à produire les **bases de l'informatique**.
 Le rôle d'Ada Lovelace dans ce projet a été tel qu'elle a été depuis qualifiée de *première programmeuse*.
+\n
 ### Alan Turing
-![Alan Turing](media/alanturing.jpg)	
+![Alan Turing](media/alanturing.jpg)
+\n
 Dans les **années 1930**, les travaux du **mathématicien** *Alan Turing* sont déterminants pour définir d'abord ce qu'est une **machine programmable** universelle, et ensuite pour dessiner les frontières de ce qu'il est possible de calculer à l'aide d'une telle machine. Turing a également eu une action déterminante pendant la **seconde guerre mondiale**. Il conçoit des machines capables de **décrypter** les messages allemands codés par la machine **Enigma**. Ses découvertes permirent, selon plusieurs historiens, de raccourcir la capacité de résistance du régime nazi de deux ans.
+\n
 Si la vie de cet homme exceptionnel au destin tragique vous intéresse nous vous conseillons les deux liens suivants :
+\n
 - [Alan Turing 1](http://future.arte.tv/fr/alan-turing)
 - [Alan Turing 2](http://videotheque.inria.fr/videotheque/doc/758)
-Vous y découvrirez entre autre une hypothèse sur l'origine du logo de la pomme croquée d'`Apple`. 
+\n
+Vous y découvrirez entre autre une hypothèse sur l'origine du logo de la pomme croquée d'`Apple`.
 ### John Von Neumann 	
 ![John Von Neumann](media/johnVonNeumann.jpg)
+\n
 Dans les **années 40**, **John Von Neumann** propose une **architecture** pour une machine programmable.
-Par architecture, il faut entendre comme dans l'habitat, une description précise de son organisation qui permet d'expliquer son fonctionnement et la construire effectivement. Notre ordinateur moderne apparaît. 
+Par architecture, il faut entendre comme dans l'habitat, une description précise de son organisation qui permet d'expliquer son fonctionnement et la construire effectivement. Notre ordinateur moderne apparaît.
+\n
 ![architecture Von Neumann](media/VonNeumannArchitecture_fr.png)
+\n
 *Von Neumann Architecture*, schéma par Chris Martin, source sous licence CC-BY-SA 3.0
+\n
 Dans ce monde numérique qui évolue si vite, il est remarquable que **deux notions fondamentales**, à savoir ce qu'il est *possible de calculer* par machine programmable défini par Turing, et cette *architecture* de machine dite de Von Neumann soient toujours celles qui régissent le fonctionnement de nos ordinateurs d'aujourd'hui.
+\n
 ### Grace Hopper
+\n
 ![Grace Hopper](media/Grace_Hopper_and_UNIVAC.jpg)
-*Grace Murray Hopper au clavier de l'UNIVAC, vers 1960.*, Smithsonian Institution, Source, photo sous licence CC-BY 2.0.	
+\n
+*Grace Murray Hopper au clavier de l'UNIVAC, vers 1960.*, Smithsonian Institution, Source, photo sous licence CC-BY 2.0.
+\n
 C'est à la **fin des années 50** que les premiers **langages** informatiques de programmation apparaissent. Ce sont des langages artificiels, c'est-à-dire inventés par l'homme, facilement lisibles et intelligibles. Un programme spécifique appelé *compilateur* ou *interprète* se charge de traduire un texte écrit dans ce langage de programmation en langage machine. Les conséquences sont importantes : la **programmation** devient accessible à un plus grand nombre d'individus, et l'écriture d'un programme n'est plus spécifique à une machine. C'est le début du **métier de programmeur**.
+\n
 Grace Hopper a inventé le **premier compilateur**. Elle est aussi à l'origine du langage `Cobol` qui a été énormément utilisé dans l'informatique de gestion. On la voit ici (photo ci-contre) au clavier de l'`UNIVAC`, vers 1960.
 }
 
 ::La vitesse des ordinateurs::
 Le **microprocesseur** qui réalise les calculs dans un ordinateur déclenche ses opérations à intervalles de temps régulier. C'est **l'horloge** qui a ce rôle de définir la cadence de travail du processeur et donc sa vitesse de calcul.  La fréquence d'horloge se mesure en kiloHertz (kHz, milliers de fois par seconde), en MégaHertz (Mhz, millions de fois par seconde) ou en GigaHertz (GHz, milliards de fois par seconde). Cela correspond au nombre maximal d'opérations élémentaires qu'un ordinateur peut effectuer **en une seconde**. Nous vous proposons de faire quelques recherches pour prendre conscience des *ordres de grandeur* et des évolutions sur les 70 dernières années.
+\n
 En vous aidant par exemple de [cette page](http://fr.wikipedia.org/wiki/Histoire_des_ordinateurs), retrouver la **date** d'apparition et la **fréquence** d'horloge (en khz, Mhz ou Ghz) de ces machines emblématiques de leur époque :
-    - l'ENIAC 
-    - Apple I
-    - IBM PC
-    - Ipad (premier modèle)
-    - smartphone Samsung Galaxy S4
+\n
+- l'ENIAC
+- Apple I
+- IBM PC
+- Ipad (premier modèle)
+- smartphone Samsung Galaxy S4
+\n
 Essayez de tracer un diagramme ou une courbe pour représenter cette évolution. Quelle difficulté rencontrez-vous et que pouvez-vous en déduire sur cette évolution ?
 {####
 ## la vitesse des ordinateurs
-[markdown]**La vitesse des ordinateurs**
+**La vitesse des ordinateurs**
+\n
 **L'ENIAC**
+\n
 ![ENIAC](media/ENIAC.gif)
+\n
 L'un des tout premiers ordinateurs, l'`ENIAC` a été réalisé en **1946**. Il avait une vitesse d'horloge de **100khz**, ce qui signifie qu'il était capable de faire **100 000 opérations élémentaires par seconde**. Ces opérations étaient par exemple des additions sur des nombres simples. Les actions complexes que l'`ENIAC` réalisait étaient *décomposées* en une multitude d'opérations élémentaires. C'est toujours le cas pour tous les programmes informatiques.
+\n
 Ces caractéristiques techniques peuvent nous paraître ridicules mais elles correspondent à calculer en **3s** ce que des mathématiciens sont capables de faire *à la main* en **3 jours**.
-### 
+\n
+###
 En **1976**, sort l'`Apple I` avec une fréquence d'horloge de **1 Mhz** (1 Million d'opérations élémentaires par seconde). En trente ans, la puissance a été **multipliée par 10** alors que l'encombrement est passé de la taille d'une maison (30 tonnes, 170 m2) à celui d'une machine qui tient sur une table.
+\n
 L'`IBM-PC` quant à lui apparaît en **1981** et *tourne* à une vitesse de **4,77Mhz**. La vitesse a donc été multipliée par presque 5 en 5 ans.
-### 
+\n
+###
 En **2010**, une des premières tablettes, l'`IPAD` est proposé sur le marché avec un processeur travaillant à 1Ghz, soit **1 milliards d'opérations élémentaires par seconde**. Notons que ces opérations élémentaires sont de plus en plus complexes, ce qui accentue encore l'augmentation de la puissance des machines. 1Ghz correspond à 200 fois 5Mhz, l'IPAD est donc plus de **200 fois plus puissant** que les premiers PC.
-### 
+\n
+###
 En **2013**, le `Samsung Galaxy S4` est un *smartphone* qui tient dans la main et dans la poche et qui a une fréquence d'horloge supérieure à **2Ghz**. On pourrait ajouter que ces machines ont plusieurs processeurs qui travaillent ensemble ce qui démultiplie là encore leurs capacités,...
+\n
 ![loi de Moore](media/graph_puissance_small.jpg)
+\n
 Comme nous l'avons précisé dans la question, la vitesse des processeurs n'est pas le seul élément à prendre en compte, mais il donne une bonne idée de l'évolution de la puissance des machines.
+\n
 Représenter cette évolution sur une courbe est particulièrement difficile, car la courbe croît tellement vite qu'elle *sort* très rapidement de la feuille. Multiplier par 2 à chaque intervalle de temps régulier définit une courbe **exponentielle**, caractéristique de la *loi de Moore* qui prédit cette évolution. Peu de technologies ont des évolutions aussi spectaculaires.
+\n
 Notons, que cette loi *empirique* (constatée, mais pas démontrée) s'arrêtera forcément un jour, la vitesse ne pouvant être infinie. Beaucoup de gens ont d'ailleurs prédit qu'à telle ou telle date, la loi ne se vérifierait plus, ... or, pour l'instant elle tient toujours, ...
 }
 
 ::D'où vient le PC ?::
 [markdown]
 **L'Ordinateur personnel**
+\n
 ![Francois Gernelle](media/FrancoisGernelle.jpg)
+\n
 Historiquement, les premiers ordinateurs étaient de très grosses machines (appelés *MainFrame* en anglais) occupant des salles entières et dédiés à des traitements de gestion. La miniaturisation a entraîné l'apparition d'ordinateurs pouvant être posés sur des bureaux. C'est la naissance de la *deuxième ère de l'informatique*.
+\n
 C'est au début des années 70,  qu'un français, *François Gernelle* (photo),  a breveté l'idée d'**ordinateur personnel**. Mais c'est au début des années 80, qu'une grande entreprise américaine du secteur informatique, `IBM` commence une production massive d'un autre modèle d'ordinateur personnel qui lui assure un succès commercial important qui va marquer le secteur pendant des années. Depuis, on dit souvent que le premier ordinateur personnel a été celui fabriqué par `IBM`, ordinateur appelé *PC* pour *Personnal Computer*.
+\n
 Faites des recherches sur l'`IBM - PC` pour répondre aux questions suivantes :
-    - En quelle année est-il apparu ?
-    - Quelle quantité en a-t-on fabriqué ?
-    - Quelle était la capacité de son disque dur ?
-    - Pourquoi le `PC` d'`IBM` est-il resté dans l'histoire ?
+\n
+- En quelle année est-il apparu ?
+- Quelle quantité en a-t-on fabriqué ?
+- Quelle était la capacité de son disque dur ?
+- Pourquoi le `PC` d'`IBM` est-il resté dans l'histoire ?
 {####
 ## D'où vient le PC ?
 ### Le PC de 1981 à aujourd'hui
+\n
 L'`IBM-PC` a fait son apparition en **1981**. Plusieurs millions d'exemplaires ont été vendu à travers la monde. Le premier modèle ne possédait **pas de disque dur**, seulement des lecteurs de disquettes. Par la suite, d'autres modèles toujours plus puissants et sophistiqués ont vu le jour. À chaque fois les nouveaux modèles étaient compatibles avec les anciens, cela signifie que les programmes qui fonctionnaient sur les anciens modèles pouvaient être réutilisés avec les nouveaux.
+\n
 `IBM` s'est associé avec `Microsoft` qui fournissait le système d'exploitation qui s'appelait alors `MS-DOS`. Celui-ci a évolué en même temps que les capacité des machines. La dernière génération connue s'appelle ... `Windows 10` !
-Grâce à son **architecture ouverte** (i.e. la "description des schémas de fonctionnement" a été diffusée), de nombreuses autres marques ont fabriqué des machines comparables en respectant des **normes** et en installant également les systèmes de `Microsoft`. On les a appelé des **compatibles PC**. Aujourd'hui, on a l'habitude de parler de `PC` et `IBM` n'a plus qu'une très petite part de ce marché. En revanche `Microsoft` reste hégémonique pour le système d'exploitation `Windows`. 
-Il faut néanmoins savoir que d'autres systèmes peuvent être installés sur les `PC`, en particulier `Linux`, qui est un système d'exploitation **rapide**, **fiable** et **puissant** qui est par certains aspects bien meilleur que `Windows`. Malheureusement, les accords commerciaux entre les constructeurs de machines et `Microsoft` rendent assez compliqués l'achat d'un `PC` équipé de `Linux`. En pratique, un PC équipé de `Linux` à la place de `Windows` est quasi introuvable dans le commerce grand public. 
+\n
+Grâce à son **architecture ouverte** (i.e. la "description des schémas de fonctionnement" a été diffusée), de nombreuses autres marques ont fabriqué des machines comparables en respectant des **normes** et en installant également les systèmes de `Microsoft`. On les a appelé des **compatibles PC**. Aujourd'hui, on a l'habitude de parler de `PC` et `IBM` n'a plus qu'une très petite part de ce marché. En revanche `Microsoft` reste hégémonique pour le système d'exploitation `Windows`.
+\n
+Il faut néanmoins savoir que d'autres systèmes peuvent être installés sur les `PC`, en particulier `Linux`, qui est un système d'exploitation **rapide**, **fiable** et **puissant** qui est par certains aspects bien meilleur que `Windows`. Malheureusement, les accords commerciaux entre les constructeurs de machines et `Microsoft` rendent assez compliqués l'achat d'un `PC` équipé de `Linux`. En pratique, un PC équipé de `Linux` à la place de `Windows` est quasi introuvable dans le commerce grand public.
+\n
 Pour l'anecdote, le texte que vous êtes en train de lire a été rédigé sur un PC sous `Linux`.
+\n
 ### Qui l'eut cru ?
+\n
 En **1984** sort la troisième génération de PC : le `PC/AT`
-extrait de wikipedia : [http://fr.wikipedia.org/wiki/IBM_PC](http://fr.wikipedia.org/wiki/IBM_PC)
+\n
+Extrait de wikipedia : [http://fr.wikipedia.org/wiki/IBM_PC](http://fr.wikipedia.org/wiki/IBM_PC)
+\n
 *La machine fut jugée suffisamment puissante — selon les critères de l'époque — pour être interdite à l'exportation vers les pays de l'Est, alors sous embargo technologique (COCOM). IBM en refusa aussi pendant deux ans la vente à prix réduit au personnel, arguant qu'un particulier ne pouvait pas avoir besoin d'une telle puissance ni d'une telle capacité disque (30 Mo), qui la destinaient plutôt aux petites et moyennes entreprises.*
 }
 
 ::Les interfaces Homme - Machine::
-**Les interfaces Homme - Machine**
 Une branche de la science informatique est l'étude des interactions entre l'homme et la machine. De ce point de vue, de nombreuses avancées ont été réalisées depuis 1945. Elles sont liées à  la fois, à des progrès technologiques, à des efforts d'ingénieurs et à des succès commerciaux, mais aussi à des avancées dans les idées. Nous vous proposons de faire quelques recherches pour appréhender l'évolution des interfaces.
+\n
 - Que doit-on à Douglas **Engelbart** ?
 - Qu'est-ce que le  **Palo Alto Research Center** ? Qu'y fait-on ?
 - Qu'est-ce que l'ordinateur **Lisa** ? Qu'a-t-il apporté de nouveau ? Qui l'a fabriqué ? En quelle année est-il apparu ?
-Par ailleurs, les ordinateurs prennent désormais des formes nouvelles et se combinent avec d'autres objets du quotidien. Effectuez des recherches pour dire ce qu'on appelle l'informatique ubiquitaire (ou informatique omniprésente) et donnez un meilleur représentant. 
+\n
+Par ailleurs, les ordinateurs prennent désormais des formes nouvelles et se combinent avec d'autres objets du quotidien. Effectuez des recherches pour dire ce qu'on appelle l'informatique ubiquitaire (ou informatique omniprésente) et donnez un meilleur représentant.
 {####
 ## Évolution des interfaces homme-machine
 ### Les interfaces ont démocratisé l'accès au numérique
+\n
 Une branche de la **science informatique** est l'étude des interactions entre l'homme et la machine.
+\n
 De ce point de vue, de nombreuses avancées ont été réalisées depuis 1945. Elles sont liées à  la fois à des progrès technologiques, des efforts d'ingénieurs et des succès commerciaux, mais aussi des avancées dans les idées.
+\n
 **Douglas Engelbart** par exemple,  était un grand spécialiste des interfaces homme-machine. Il a créé le premier **prototype de souris** (ci-contre) en **1968**. Il avait imaginé également les interfaces graphiques qui apparaîtront plus tard. En attendant, les écrans n'affichaient que du texte, ligne par ligne et les commandes étaient entrées avec un clavier. Les **cartes perforées** étaient également très utilisées pour ne pas avoir à re-saisir les programmes à chaque utilisation.
+\n
 ![Le premier prototype de souris](media/Douglas_Engelbart's_prototype_mouse.jpg)
-*Le premier prototype de souris, développé par Douglas Engelbart*. 
-Photo par Michael Hicks, source sous licence CC-BY 2.0.
-	[Pour en savoir plus sur Doug Engelbart.](http://www.silicon.fr/in-memoriam-doug-engelbart-pere-de-la-souris-87561.html) 
+\n
+*Le premier prototype de souris, développé par Douglas Engelbart*. Photo par Michael Hicks, source sous licence CC-BY 2.0.
+\n
+[Pour en savoir plus sur Doug Engelbart.](http://www.silicon.fr/in-memoriam-doug-engelbart-pere-de-la-souris-87561.html)
+\n
 C'est également au **P.A.R.C**. qu'est apparue la notion d'informatique **ubiquitaire** qui est considérée comme la **troisième ère de l'informatique**. La première étant celle des *gros systèmes* (MainFrame), la deuxième apparue dans les années 80, celle des *ordinateurs personnels* (PC et Mac). L'emblème de cette informatique ubiquitaire est le **smartphone**, un ordinateur très puissant qui ne nous quitte presque plus, et qui nous permet d'être connecté en permanence.
+\n
 On parle aussi, d'informatique *omniprésente* ou *d'intelligence ambiante.*
+\n
 Les **objets connectés**, de plus en plus présents, participent également à cette évolution. Cette omniprésence de l'accès à l'information a un fort impact sur la société, modifie les habitudes de travail et de vie privée.
+\n
 ![Lisa](media/Apple_Lisa_2.jpg)
+\n
 *Le Lisa*, photo par Marcin Wichary, source sous licence CC-BY 2.0.
+\n
 En **1983**, Apple achète pour 40 000$, une licence pour le brevet de la souris, et sort le premier ordinateur personnel équipé d'une souris et d'une interface graphique : le **Lisa**. Il va révolutionner le marché des ordinateurs personnels qui débutait (2 ans après le premier PC). Parmi les concepteurs du Lisa, on retrouvera **Steve Jobs**, un autre visionnaire qui fera la carrière qu'on connaît chez `Apple`.
 }
 ```
@@ -414,16 +498,16 @@ par n'importe quel chemin à l'intérieur d'internet.
 ```comprehension
 ::signification d'internet::
 [markdown]**Que signifie internet ?**
-{ 
+{
 ~Il s'agit de la contraction des mots anglais : *international* et *network* (réseau international).#Ça aurait pu, mais non !
 =Il s'agit de la contraction des mots *interconnection* et *networks* (interconnexion de réseaux).#Exactement !
-~Les lettres du mot I.N.T.E.R.N.E.T sont les initiales des noms de ses 8 fondateurs.#Pas du tout ! 
+~Les lettres du mot I.N.T.E.R.N.E.T sont les initiales des noms de ses 8 fondateurs.#Pas du tout !
 ####Internet est la contraction des deux mots anglais "interconnection" et "networks", qui signifie "interconnexion de réseaux".}
 
 
 ::Âge d'internet::
-[markdown]**Quelle est la date la plus proche de la création d'internet ?** 
-{ 
+[markdown]**Quelle est la date la plus proche de la création d'internet ?**
+{
 ~1789#Vraiment ?
 ~1918#N'est-ce pas un peu tôt ?
 ~1945#N'est-ce pas un peu tôt ?
@@ -446,45 +530,62 @@ informations.#Tout à fait !
 ```activité-avancée
 ::Qui a inventé internet ?::
 On a parfois une représentation erronée du rôle des différents pays dans la **création** d'internet. Faites des recherches sur les deux personnes suivantes pour rétablir un juste équilibre.
+\n
 - Qui est Vinton « Vint » Gray Cerf ? Comment est-il parfois surnommé ?
 - Qui est Louis Pouzin ? Qu'était le projet Cyclades ?
+\n
 Après vous être documenté sur ces deux personnages importants, rédigez une courte réponse qui résume ce que vous avez appris.
 {####
 ## Qui a inventé internet ?
 ### Vinton Gray Cerf
+\n
 ![Vinton Cerf](media/vintoncerf.jpg)
-*Dr. Vint Cerf*, photo de Veni Markovski,
-source sous licence CC-BY 3.0.
+\n
+*Dr. Vint Cerf*, photo de Veni Markovski, source sous licence CC-BY 3.0.
+\n
 *Extrait de Wikipédia*
+\n
 >Vinton « Vint » Gray Cerf, né le 23 juin 1943 à New Haven, Connecticut, États-Unis, est un ingénieur américain, chercheur et co-inventeur avec Bob Kahn du protocole TCP/IP. Il est considéré comme l'un des pères fondateurs d'internet.
+\n
 Il est souvent appelé le *père d'internet*.
+\n
 ### Louis Pouzin
+\n
 ![louis Pouzin](media/louispouzin.jpg)
+\n
 *Louis Pouzin*, Photo de Jérémie Bernard, source sous licence CC-BY-SA 3.0.
+\n
 *Extrait de Wikipedia*
+\n
 >Cyclades était un projet expérimental français ayant pour but de créer un réseau global de télécommunication utilisant la commutation de paquets. Créé en 1971, conçu par Louis Pouzin, il fut abandonné en 1978. Ses concepts ont influencé les travaux de développement d'internet en inspirant sa suite de protocoles.
+\n
 Si vous voulez écouter son **avis** sur ce qu'est devenu internet, voici une vidéo très intéressante :
 [Louis Pouzin Youtube](https://youtu.be/p70Go9IS1h4)
 }
 
 ::Qui a accès à internet ?::
 Effectuez des recherches pour répondre aux questions qui suivent. Vous pouvez commencer vos recherches à partir de  [cette page sur l'histoire](http://fr.wikipedia.org/wiki/Histoire_d'Internet) et [cette page qui donne des statistiques d'utilisation](http://www.blogdumoderateur.com/chiffres-internet/)
+\n
 - Combien y avait-il dans le monde d'ordinateurs connectés en 1984 ? En 1987 ? En 1989 ? Aujourd'hui ?
-- en quelle année a-t-on passé la barre du million d'utilisateurs ? 
+- en quelle année a-t-on passé la barre du million d'utilisateurs ?
 - Quelle proportion de la population mondiale n'a pas accès à internet ?
 - À l'inverse, quelle proportion a accès à internet en France ? Est-ce supérieur ou inférieur à la moyenne européenne ? Est-ce supérieur ou inférieur à la moyenne aux USA ?
 - En 1 minute, dans le monde, combien de recherche Google ? Combien de mails sont envoyés ? Combien de contenus sont partagés sur Facebook ?
 {####
 ## Qui a accès à internet ?
+\n
 L'accès à internet a considérablement évolué en quelques années. Néanmoins, de grandes **inégalités** persistent encore.
+\n
 Le nombre d'ordinateurs connectés permet de faire une approximation du nombre de personnes qui utilisent internet.
 Il y avait **1000 machines connectées en 1984**, 3 ans plus tard 10 fois plus, c'est à dire **10 000 en 1987**. Cela a encore été multiplié par 10 dans les 2 années qui suivirent, soit **100 000 machines en 1989**. Puis le **million** d'utilisateurs a été franchi en **1992**.
 22 ans plus tard, nous en sommes à presque **3 milliards d'utilisateurs** à travers le monde. Il n'existe certainement rien d'autre à travers l'histoire qui ait connu une telle évolution !
 Et pourtant, la population mondiale est supérieure à 7 milliards, ce qui nous permet de nous rendre compte que **plus de la moitié de la population mondiale** n'a toujours **pas accès** à internet !
 En **France** en 2014, **83%** de la population est connectée, un taux supérieur à la moyenne européenne et supérieur aussi à celui des États-Unis.
+\n
 Enfin, pour tenter de mesurer l'ampleur des informations échangées sur internet, regardons ce qui ce passe en moyenne chaque minute :
+\n
 - 4 millions de recherches Google
-- 200 millions de mails envoyés 
+- 200 millions de mails envoyés
 - 2,46 millions de contenus partagés sur Facebook
 }
 ```
@@ -583,22 +684,32 @@ ordinateur qu'à afficher ce contenu.
 ::Combien y-a-t-il d'adresses IP ?::
 [markdown]
 **Plus assez d'adresses IP ?**
+\n
 Les fondateurs d'internet n'envisageaient sûrement pas le succès phénoménal qu'il a rencontré. Aussi, le système de numérotation des adresses `IP` n'a pas été prévu suffisamment large pour répondre au nombre d'utilisateurs grandissant. Nous sommes depuis quelques années arrivés à un stade de **pénurie d'adresses IP**. La norme a donc dû évoluer. Aujourd'hui, deux normes cohabitent en attendant que tous les anciens systèmes s'adaptent à la nouvelle. Ces deux normes portent les noms de `IPV4` et `IPV6`. Faites des recherches sur ces normes pour répondre aux 2 questions suivantes :
+\n
 - Dans la norme IP version 4 `IPV4`, un numéro est composé de 4 nombres entre 0 et 255. Avec cette norme, y a-t-il plus de numéro IP possibles que d'êtres humains sur terre ?
 - Nouvelle norme IP version 6 `IPV6`. Combien pourrait-on avoir de numéros IPV6 différents par millimètre carré de la surface de la terre ?
 {####
 ## Combien y-a-t-il d'adresses IP ?
 ### `IP V4` : nombre d'adresses *vs* nombre d'êtres humains
+\n
 La population mondiale est supérieure à 7 milliards, or le système `IPV4` ne peut représenter que 4 milliards (4 294 967 296 = (2^^32^ )) d'adresses, ce qui est largement insuffisant.
 L'apparition entre autre des *objets connectés* et des appareils mobiles fait exploser la demande et on entrevoit que cette demande va considérablement augmenter dans un avenir proche.
+\n
 ### `IP V6`, on voit les choses en grand
+v
 Heureusement, la nouvelle norme `IPV6` est quand à elle beaucoup plus généreuse :
+\n
 *Extrait wikipedia* : [http://fr.wikipedia.org/wiki/IPv6](http://fr.wikipedia.org/wiki/IPv6)
+\n
 `l'augmentation de 2^^32 (soit environ 4,3×109) à 2128 (soit environ 3,4×1038) du nombre d'adresses disponibles.
 Pour épuiser la totalité de ce stock d'adresses, il faudrait placer 667 millions de milliards d'appareils connectés sur chaque millimètre carré de la surface de la Terre`
 Cette fois on peut espérer tenir avec ce système un bon moment.
+\n
 ### Le numérique compte en binaire :
+\n
 Nous n'avons pas encore vu comment on code les informations en binaire. Pour tous ceux d'entre vous qui n'ont pas de culture scientifique, cela peut paraître abstrait. On peut quand même remarquer que les résultats ci-dessus s'expliquent en calculant de la façon suivante :
+\n
 - `IPV4` utilise des adresses codées sur 32 bits, le nombre de combinaisons est alors 2^32.
 - `IPV6` code les adresses sur 128 bits, ce qui fait 2^128 adresses possibles.
 }
@@ -606,8 +717,11 @@ Nous n'avons pas encore vu comment on code les informations en binaire. Pour tou
 ::Les serveurs de noms::
 [markdown]
 **Les serveurs de noms : un maillon fragile de l'édifice**
+\n
 La norme qui régit le fonctionnement des serveurs de noms propose une organisation pyramidale des machines. Les machines au sommet de cette pyramide sont les **serveurs racine de DNS** ( DNS pour Domain Name System, en français, on parle de système de nom de domaine).
+\n
 À partir de [cette ressource](http://fr.wikipedia.org/wiki/Serveur_racine_du_DNS), faites les recherches nécessaires pour répondre aux questions suivantes :
+\n
 - Si ces machines s'arrêtaient, la traduction des adresses `IP` en nom et vice-versa s'arrêterait. Quel serait, à votre avis, l'impact de cet arrêt ?
 - Combien existe-t-il de serveurs racine de DNS ?
 - Qui possède ces machines : des états, des organisations, des sociétés privées ?
@@ -616,9 +730,11 @@ La norme qui régit le fonctionnement des serveurs de noms propose une organisat
 {####
 ## Les serveurs de noms [correction]
 ### Les serveur racines de DNS
+\n
 Si les serveurs racines de DNS **s'arrêtaient**, alors progressivement les millions de serveurs de noms répartis sur la planète qui en dépendent deviendraient obsolètes et la **correspondance** entre les noms des machines, que nous utilisons et les adresses IP **ne fonctionnerait plus**. En d'autres termes **internet s'arrêterait**.
 Or, il n'existe que **13** serveurs racines, ils sont détenus (sécurisés et entretenus) par des **états**, des sociétés **commerciales** **privées** ou des **organisations**. Les machines qui hébergent ces serveurs sont majoritairement situées sur le **sol américain** et donc soumis au **droit américain**, alors que l'ensemble de la planète en dépend.
 Beaucoup de gens pensent que cela constitue un problème, un bien commun universel aux mains de quelques-uns, soumis aux lois d'un seul pays, peut-on, doit-on faire confiance à des sociétés privées pour prendre les décisions qui concernent la gestion, la sécurité et le bon fonctionnement d'éléments aussi cruciaux que les serveurs racines de DNS. Certains militent pour une vision plus démocratique avec des décisions partagées.
+\n
 Vous êtes maintenant en capacité de comprendre ces questions pour vous forger votre propre opinion.
 Ces serveurs racines sont des points faible du système, si l'un d'entre eux devient indisponible, alors c'est un 13ème de la charge qui qui doit être réparti sur les douze autres. Vu le nombre gigantesque de requêtes effectuées en permanence, cela peut ralentir l'ensemble du réseau à l'échelle de la planète.
 C'est ce qui s'est passé en **2002** et en **2007**, lorsque des serveurs racines ont été la cible de **cyber attaques**.
@@ -628,17 +744,24 @@ C'est ce qui s'est passé en **2002** et en **2007**, lorsque des serveurs racin
 ::Panne générale::
 [markdown]
 **Panne générale**
-Dans le petit schéma ci-dessous, un nuage représente un réseau local. Les petits carrés sont des routeurs ou des ordinateurs. 
+\n
+Dans le petit schéma ci-dessous, un nuage représente un réseau local. Les petits carrés sont des routeurs ou des ordinateurs.
+\n
 ![routeurs](media/exoInternet.svg)
+\n
 Supposons que les communications dans chaque réseau local fonctionnent correctement, c'est-à-dire que chaque ordinateur d'un réseau local peut communiquer avec n'importe quel ordinateur du même réseau local. L'ordinateur A doit échanger des données avec l'ordinateur B.
+\n
 - Indiquer le groupe minimal de routeurs qui devraient tomber en panne pour empêcher la communication entre A et B ?
-- Dans le cas des câbles, quel ensemble minimal de câbles devraient être coupés pour empêcher la communication entre A et B ? 
+- Dans le cas des câbles, quel ensemble minimal de câbles devraient être coupés pour empêcher la communication entre A et B ?
 - Lister tous les chemins possibles (sans boucle) qui permettent de relier A à B.
-{
-#### Si les routeurs C et D tombent en panne le réseau local de A est déconnecté et A ne peut plus communiquer avec B. 
-La même chose se produit si les routeurs H et I tombent en panne. 
-Si F et I tombent en panne, alors les communications passent encore par D, E, K et H.
-Les câbles entre C-F, C-I, D-E, de la même façon isolent le réseau de A.
+{####
+Correction
+\n
+- Si les routeurs C et D tombent en panne le réseau local de A est déconnecté et A ne peut plus communiquer avec B.
+- La même chose se produit si les routeurs H et I tombent en panne.
+- Si F et I tombent en panne, alors les communications passent encore par D, E, K et H.
+- Les câbles entre C-F, C-I, D-E, de la même façon isolent le réseau de A.
+\n
 A-C-I-B ; A-C-F-I-B ; A-C-F-H-B ; A-C-F-E-K-H-B ; A-D-E-K-H-B ; A-D-E-F-H-B ; A-D-E-F-I-B
 }
 ```
@@ -722,69 +845,27 @@ interconnexion devient obligatoire.
 ```comprehension
 ::Rejoindre le réseau::
 [markdown]Lorsqu'un ordinateur rejoint un réseau, que doit-il
-obtenir pour rejoindre internet ?{ 
-~%33.33333%Une adresseIP.#Oui, entre autres... 
+obtenir pour rejoindre internet ?
+{
+~%33.33333%Une adresseIP.#Oui, entre autres...
 ~Un nom de code.#Et non... ~Une autorisation de l'État ?#Vraiment ?
 ~%33.33333%L'adresse d'un serveur de noms.#C'est bien l'un
-des éléments. 
-~%33.33333%L'adresse d'un routeur.#Oui, mais pas seulement. ~L'accès à un moteur de recherche.#Pas du tout. 
+des éléments.
+~%33.33333%L'adresse d'un routeur.#Oui, mais pas seulement. ~L'accès à un moteur de recherche.#Pas du tout.
 ####En fait, il doit obtenir 3 éléments \: une adresse IP, l'adresse d'un serveur de noms et l'adresse d'un routeur. }
+
 
 ::le routeur::
 [html]Pourquoi la machine qui assure l'interconnexion avec
 les autres réseaux d'internet (le routeur) est-elle une place de choix
-pour y installer des fonctions de filtrage ?{ 
-=Parce que toutes les informations passent par là.#C'est exact ! 
+pour y installer des fonctions de filtrage ?
+{
+=Parce que toutes les informations passent par là.#C'est exact !
 ~Parce que c'est la machine la plus puissante.#Et bien, non.
 ~Parce qu'elle est en général bien cachée.#Pas du
-tout... 
+tout...
 ####Parce que toutes les informations transitent par elle. }
-```
 
-```activité
-
-::Utiliser les serveurs de noms::
-[markdown]
-**Utiliser les serveurs de noms**
-Il existe des *outils* dans votre ordinateur pour interroger les serveurs de noms et faire donc la *conversion* entre `adresses IP` et `noms`. Ils sont intégrés par exemple dans le navigateur web et la plupart des outils qui utilisent internet. Même s'il est possible de les utiliser directement, ils sont assez techniques.
-Nous vous proposons d'utiliser plutôt un **service** disponible sur internet à travers le navigateur : [http://www.monip.fr](http://www.monip.fr)
-Selon ce site ;
-  - quelle est votre adresse IP ?
-  - où vous trouvez-vous ?
-D'après ce site, où se trouvent les machines suivantes :
-  - [www.wikipedia.org](www.wikipedia.org)
-  - [www.facebook.com](www.facebook.com)
-  - [www.google.com](www.google.com)
-Quelle est l'adresse IP de la machine qui porte le nom [www.grappa.univ-lille3.fr](www.grappa.univ-lille3.fr) ?
-**Copiez** l'adresse IP que vous venez de  trouver dans la **barre d'adresse de votre navigateur.** Dans un autre onglet, **copiez** le **nom** : www.grappa.univ-lille3.fr dans la barre d'adresse.
-- Que constatez vous ?
-Une fois validé votre rendu, vous pourrez consulter la correction pour vous auto-évaluer, ...
-{####
-## Utiliser les serveurs de noms
-### Votre propre IP
-Grâce à [http://www.monip.fr](http://www.monip.fr) vous avez trouvé votre adresse IP, elle est évidemment différente pour chacun d'entre nous.
-Si vous recommencez depuis une autre machine ou avec la même machine connectée différemment (wifi domicile ou wifi eduroam, connexion filaire à l'université ou eduroam université, connexion wifi ou connexion 3G/4G) vous obtiendrez à chaque fois un résultat **différent**.
-Pour ce qui est de la **localisation**, vous avez sûrement obtenu une adresse géographiquement proche de la votre, celle-ci est en fait l'*adresse du  routeur du fournisseur d'accès* du réseau auquel vous êtes connecté.
-Vous pouvez également constater que vos informations personnelles telles que :
-- le navigateur que vous utilisez,
-- la langue utilisée,
-- la taille de votre écran, ... 
-ont été **repérés** par le site www.monip.fr et vous sont renvoyés dans la liste des informations.
-### Wikipedia, facebook et google
-Vous avez dû trouver que la localisation de wikipedia est aux *Pays-Bas*, près *d'Amsterdam*. C'est en effet là que se trouve la copie la plus proche.
-D'autres répliques de la célèbre encyclopédie existent également en *Floride* et en *Corée du  Sud*.
-`Facebook` est hébergé à *Kensington*, dans *l'Ohio* aux *États-Unis*, c'est là que les *données* de tous les utilisateurs sont stockées.
-Alors que `Google` se trouve à *Mountain View* en *Californie*.
-Toutes les **lois** concernant la sécurisation de nos données et les respect de **notre vie privée** pour ces 2 sites sont donc des lois **américaines**.
-### www.monip.fr
-et oui, ce site est une version traduite en français d'un site Allemand.
-### www.grappa.univ-lille3.fr
-l'adresse **IP** de l'équipe de recherche Grappa est : `194.254.132.190`
-Si vous copiez cette adresse dans dans la barre d'adresse de votre navigateur, vous tombez exactement sur la **même page** que si vous allez sur [www.grappa.univ-lille3.fr](www.grappa.univ-lille3.fr).
-Cela ne doit pas vous surprendre si vous avez compris l'objet de cette séquence.}
-```
-
-```comprehension
 
 ::La charte informatique de l'université::
 [markdown]**La charte informatique de l'université**
@@ -797,14 +878,78 @@ Si vous vous connectez avec la **4G** depuis l'université, devez-vous respecter
 2/ Si vous vous connectez avec la **4G** depuis l'université, devez-vous respecter cette charte ? Et avec votre smartphone et une connexion wifi ?  
 OUI et OUI, les services numériques en particulier ceux accessibles depuis **l'ENT** sont soumis à cette charte **quel que soit le mode de connexion**. En revanche, si vous vous connectez en 4G à d'autres sites que ceux de l'université tout en étant physiquement dans les batiments de l'établissement, aucune information ne sera collectée par l'université.
 }
+
+
 ```
+
+```activité
+
+::Utiliser les serveurs de noms::
+[markdown]
+**Utiliser les serveurs de noms**
+\n
+Il existe des *outils* dans votre ordinateur pour interroger les serveurs de noms et faire donc la *conversion* entre `adresses IP` et `noms`. Ils sont intégrés par exemple dans le navigateur web et la plupart des outils qui utilisent internet. Même s'il est possible de les utiliser directement, ils sont assez techniques.
+Nous vous proposons d'utiliser plutôt un **service** disponible sur internet à travers le navigateur : [http://www.monip.fr](http://www.monip.fr)
+Selon ce site :
+  - quelle est votre adresse IP ?
+  - où vous trouvez-vous ?
+\n
+D'après ce site, où se trouvent les machines suivantes :
+\n
+  - [www.wikipedia.org](www.wikipedia.org)
+  - [www.facebook.com](www.facebook.com)
+  - [www.google.com](www.google.com)
+  \n
+Quelle est l'adresse IP de la machine qui porte le nom [www.grappa.univ-lille3.fr](www.grappa.univ-lille3.fr) ?
+\n
+**Copiez** l'adresse IP que vous venez de  trouver dans la **barre d'adresse de votre navigateur.** Dans un autre onglet, **copiez** le **nom** : www.grappa.univ-lille3.fr dans la barre d'adresse.
+\n
+- Que constatez vous ?
+\n
+Une fois validé votre rendu, vous pourrez consulter la correction pour vous auto-évaluer, ...
+{####
+## Utiliser les serveurs de noms
+### Votre propre IP
+\n
+Grâce à [http://www.monip.fr](http://www.monip.fr) vous avez trouvé votre adresse IP, elle est évidemment différente pour chacun d'entre nous.
+Si vous recommencez depuis une autre machine ou avec la même machine connectée différemment (wifi domicile ou wifi eduroam, connexion filaire à l'université ou eduroam université, connexion wifi ou connexion 3G/4G) vous obtiendrez à chaque fois un résultat **différent**.
+\n
+Pour ce qui est de la **localisation**, vous avez sûrement obtenu une adresse géographiquement proche de la votre, celle-ci est en fait l'*adresse du  routeur du fournisseur d'accès* du réseau auquel vous êtes connecté.
+Vous pouvez également constater que vos informations personnelles telles que :
+\n
+- le navigateur que vous utilisez,
+- la langue utilisée,
+- la taille de votre écran, ...
+\n
+ont été **repérés** par le site www.monip.fr et vous sont renvoyés dans la liste des informations.
+\n
+### Wikipedia, facebook et google
+\n
+Vous avez dû trouver que la localisation de wikipedia est aux *Pays-Bas*, près *d'Amsterdam*. C'est en effet là que se trouve la copie la plus proche.
+D'autres répliques de la célèbre encyclopédie existent également en *Floride* et en *Corée du  Sud*.
+`Facebook` est hébergé à *Kensington*, dans *l'Ohio* aux *États-Unis*, c'est là que les *données* de tous les utilisateurs sont stockées.
+Alors que `Google` se trouve à *Mountain View* en *Californie*.
+Toutes les **lois** concernant la sécurisation de nos données et les respect de **notre vie privée** pour ces 2 sites sont donc des lois **américaines**.
+\n
+### www.monip.fr
+\n
+et oui, ce site est une version traduite en français d'un site Allemand.
+\n
+### www.grappa.univ-lille3.fr
+\n
+l'adresse **IP** de l'équipe de recherche Grappa est : `194.254.132.190`
+Si vous copiez cette adresse dans dans la barre d'adresse de votre navigateur, vous tombez exactement sur la **même page** que si vous allez sur [www.grappa.univ-lille3.fr](www.grappa.univ-lille3.fr).
+Cela ne doit pas vous surprendre si vous avez compris l'objet de cette séquence.}
+```
+
+
 
 # Les supports physiques de transmission de l'information
 
 ## Cours
 
 [Les supports physiques](https://vimeo.com/122104443){: .cours_video }
-  
+
 [Connexions nomades](https://vimeo.com/122104499){: .cours_video }
 
 Internet et plus généralement les réseaux informatiques peuvent
@@ -887,7 +1032,7 @@ tels que des ordinateurs portables, des tablettes ou des
 smartphones. Fondamentalement, elles permettent toutes la même chose,
 c'est à dire un accès complet à internet.
 
- 
+
 ### Les connexions nomades
 
 
@@ -947,8 +1092,8 @@ du mode de connexion utilisé peut faire des miracles. Soyez agiles !!!
 ::les supports de connexion::
 [markdown]**Quels supports sont utilisés pour la transmission de données** et qui peuvent donc servir pour une connexion internet ?
 {
-~L'eau dans un tuyau.#Pas à notre connaissance, mais pourquoi pas ? 
-~%20%L'électricité dans les câbles téléphonique.#Oui, l'ADSL 
+~L'eau dans un tuyau.#Pas à notre connaissance, mais pourquoi pas ?
+~%20%L'électricité dans les câbles téléphonique.#Oui, l'ADSL
 ~%20%L'électricité dans les câbles spécialisés.#Oui, l'électricité dans les câbles des prises électriques (Voir http://fr.wikipedia.org/wiki/Courants_porteurs_en_ligne)
 ~%20%La lumière dans les fibres optiques.#Oui, aussi.
 ~%20%Les ondes électromagnétiques dans l'air.#Oui, Wifi, bluetooth, réseau téléphonique 2G, 3G, 4G, etc.
@@ -957,11 +1102,11 @@ du mode de connexion utilisé peut faire des miracles. Soyez agiles !!!
 
 ::vitesse de connexion::
 [markdown]**Qu'est-ce qui joue sur la vitesse d'une connexion ?**
-{ 
-~%25%Le débit maximal admissible du lien qui me raccorde au réseau local.#Oui, c'est l'un des paramètres. 
-~%25%Le nombre d'utilisateurs de ce lien.#Exact, c'est l'un des paramètres. 
+{
+~%25%Le débit maximal admissible du lien qui me raccorde au réseau local.#Oui, c'est l'un des paramètres.
+~%25%Le nombre d'utilisateurs de ce lien.#Exact, c'est l'un des paramètres.
 ~%25%Le nombre de messages qui passent par les mêmes routeurs que les miens.#Oui, c'est un paramètre.
-~%25%Le nombre de requêtes arrivant sur la machine avec qui je désire échanger des messages.#Oui. 
+~%25%Le nombre de requêtes arrivant sur la machine avec qui je désire échanger des messages.#Oui.
 ~L'âge de l'utilisateur.#Sans commentaire !
 ####Le débit maximal admissible du lien, le nombre d'utilisateurs de ce lien, le nombre de requêtes mais aussi le nombre de messages qui passent par les mêmes routeurs que les miens.
 }
@@ -970,9 +1115,9 @@ du mode de connexion utilisé peut faire des miracles. Soyez agiles !!!
 [markdown]**Eduroam**
 Pour utiliser le wifi à Lille 3 je dois :
 {
-=Avoir un compte Lille 3 ou un compte dans une autre université.#Exact ! 
+=Avoir un compte Lille 3 ou un compte dans une autre université.#Exact !
 ~Payer un abonnement.#Absolument pas, c'est gratuit.
-~Aller en cours.#Aucun rapport ! 
+~Aller en cours.#Aucun rapport !
 ~Utiliser un smartphone produit en France.#Aucun rapport !
 ~Signer la charte graphique de Lille 3.#Non mais signer la charte informatique Lille 3 est obligatoire...
 ####Avoir un compte Lille 3 valide ou un compte dans une autre université. }
@@ -982,43 +1127,53 @@ Pour utiliser le wifi à Lille 3 je dois :
 ::Wifi ou Données mobiles ?::
 [markdown]
 **Wifi ou Données mobiles ?**
+\n
 Les possesseurs de tablette ou de smartphone peuvent se connecter à internet via le **Wifi** ou le **réseau téléphonique** (*données mobiles 3G/4G*). Vaut-il mieux se connecter avec l'un ou avec l'autre ?
 La réponse dépend de trois paramètres :
-    - la **disponibilité** de ces modes de connexions (s'il n'y a pas de réseau wifi, il sera difficile de vous connectez en wifi…)
-    - le **prix** de la connexion
-    - la **rapidité** de la connexion
+\n
+- la **disponibilité** de ces modes de connexions (s'il n'y a pas de réseau wifi, il sera difficile de vous connectez en wifi…)
+- le **prix** de la connexion
+- la **rapidité** de la connexion
+\n
 Imaginons plusieurs situations concrètes :
-1/  je suis chez moi avec un *smartphone*, le domicile est équipée d'une *Box adsl* qui fournit un accès *Wifi*. Ai-je intérêt à me connecter :
+\n
+1. je suis chez moi avec un *smartphone*, le domicile est équipée d'une *Box adsl* qui fournit un accès *Wifi*. Ai-je intérêt à me connecter :
         - avec le réseau de données mobiles (3G ou 4G)
         - via le Wifi de la maison
-2/ Je suis à *l'université* et je veux me connecter avec mon *smartphone*. Ai-je intérêt à me connecter :
+2. Je suis à *l'université* et je veux me connecter avec mon *smartphone*. Ai-je intérêt à me connecter :
         - avec le wifi de l'université (réseau eduroam)
         - avec mon forfait 3G/4G
-3/ Je suis en *voiture* (ce n'est pas moi qui conduis) et je veux consulter mes *emails* ou faire une *recherche* sur le net avec mon *smartphone*, ai-je intérêt à me connecter :
+3. Je suis en *voiture* (ce n'est pas moi qui conduis) et je veux consulter mes *emails* ou faire une *recherche* sur le net avec mon *smartphone*, ai-je intérêt à me connecter :
         - en wifi
         - avec le réseau de données mobiles de mon opérateur téléphonique
 {####
 ## Wifi ou données mobiles ?
 ### Wifi ou données mobiles : Comment choisir ?
+\n
 1/ Chez moi avec un **smartphone**, j'ai intérêt à me connecter avec le **wifi** de la **Box adsl**.
 En effet, la connexion Wifi a déjà été payée dans le cadre de l'abonnement ADSL, la connexion du smartphone ou de la tablette n'engendre donc pas de frais supplémentaires.
 Par contre la connexion au réseau 3G/4G est décomptée du forfait qui est souvent limité.
+\n
 2/ **L'université** a investi dans le réseau wifi `eduroam`pour proposer ce service aux usagers, il est donc *gratuit* et n'entraîne aucun frais de connexion.
 En revanche comme dans l'exemple précédent, les forfaits *données mobiles* des abonnements téléphoniques sont souvent limités et/ou chers.
 Le réseau Wifi de l'université s'appelle eduroam et tous les usagers peuvent s'y connecter.
+\n
 3/ En **voiture**, si ce n'est pas moi qui conduit, je peux me connecter à internet en utilisant la connexion **3G/4G**.
 Elle permet de rester connecté sur de grandes distances. La couverture en agglomération et dans les zones de forte densité démographique est en général assez bonne pour l'ensemble des opérateurs,
 en revanche dans les zones plus reculées, il est parfois difficile de *trouver du réseau*. Et là tous les opérateurs n'ont pas la même couverture.
 La courte portée des antennes Wifi ne permet pas d'utiliser ce mode connexion lors de déplacements importants.
+\n
 ### Le saviez-vous ? - Le relai Wifi
+\n
 On trouve dans certaines villes des bus  proposant un accès Wifi.
 Si ceux-ci sont équipés d'une antenne de réception 4G, ils peuvent ensuite "redistribuer" la connexion en Wifi, à l'intérieur du véhicule.
 Cela est également **possible** avec des **smartphones** récents. Sur le principe décrit ci-dessus, un smartphone peut se connecter à un réseau 3G/4G et ensuite se comporter comme une borne wifi à laquelle peuvent se connecter d'**autres périphériques**.
-Cela est très pratique pour se connecter avec un ordinateur là où seules des connections 3G/4G seraient disponibles ... mais attention à la facture ! 
+Cela est très pratique pour se connecter avec un ordinateur là où seules des connections 3G/4G seraient disponibles ... mais attention à la facture !
  }
 
 ::Les normes et leurs sigles::
 **Classez ces modes de connexion du plus lent au plus rapide.**
+\n
 3G,4G,H+,Edge
 {
 3G -> 2
@@ -1027,44 +1182,53 @@ H+ -> 3
 E (Edge) -> 1
 ####
 # Les normes et leurs sigles
+\n
 - Les modes de connexion du plus lent au plus rapide.
     - E (Edge) aussi appelé 2G, lent. Ce mode de connexion permet à peine de lire ses mails. Il ne permet pas une navigation fluide sur le Web.
     - 3G (3ème génération) permet de faire des recherches et de surfer sans trop attendre.
     - H+, est une amélioration de la 3G. il est plus rapide que le wifi si les connexions sont optimales. Et l'accès à la musique en ligne où aux vidéos peut être envisagé.
     - 4G, plus rapide que le wifi si les connexions sont optimales. À condition bien sûr que cette connexion soit de bonne qualité ("plusieurs petites briques"), l'accès à internet est alors très fluide, et les jeux en ligne, les vidéos en streaming ou le téléchargement de gros fichiers devient possible.
+\n
 Notez bien que pour pouvoir bénéficier d'une connexion 4G, il faut :
+\n
  - que cette connexion soit disponible là où vous vous trouvez,
  - que votre smartphone soit équipé d'une antenne 4G, c'est loin d'être le cas sur tous les modèles y compris sur des appareils récents.
  }
-```
- 
-``` activité-avancée
+
 ::Les débits::
 [markdown]
 **Pouvoir évaluer les ordres de grandeur**
+\n
 Le **débit** est une des mesures caractérisant la **qualité** d'une connexion. Il mesure la quantité d'information que l'on peut transmettre à chaque seconde. Pour mesurer le débit d'une connexion, il faut d'abord savoir ce qu'est un bit. Un bit est l'élément d'information de base manipulé par un ordinateur qui ne peut prendre comme valeur que 0 ou 1. Toutes les données dans un ordinateur sont codées en une suite de bits. Transmettre des données numérisées c'est donc transmettre des bits.
+\n
 Généralement le débit est mesuré en bit par seconde `bit/s` ou ses variantes : (kilo-bit par seconde `kbit/s`, mille bits par seconde,  mega-bit par second `Mbit/s`, un million de bits par seconde, giga-bit par seconde `Gbit/s`, un milliard de bits par seconde)
+\n
 Du débit, dépend notamment le *temps* nécessaire pour télécharger un morceau de musique ou la qualité d'une vidéo lue en continu.
 Le nombre de bits que l'on peut stocker sur un DVD Blu-ray double couche est 50 gigaoctets (Go), soit 400 gigabits, car un octet est une séquence de 8 bits. Calculer le temps de transmission d'un DVD Blu-ray double couche complet dans les cas suivants:
+\n
     - l'ADSL à 10Mb/s
     - La fibre à 1Gb/s
     - Le wifi à 50Mb/s
     - La 3G à 384 Kb/s
     - La 4G à 150Mb/s
 {
-####Un DVD Blu-ray double couche a une capacité de 50 gigaoctets (Go), soit 400 gigabits 400 gigabits (Gb), soit encore 400 000 megabits (Mb). Un octet étant une séquence de 8 bits, la capacité s'écrit également 400 000 000 kilobits (Kb).
+####
+Un DVD Blu-ray double couche a une capacité de 50 gigaoctets (Go), soit 400 gigabits 400 gigabits (Gb), soit encore 400 000 megabits (Mb). Un octet étant une séquence de 8 bits, la capacité s'écrit également 400 000 000 kilobits (Kb).
+\n
 Pour obtenir le temps, il faut bien-sûr diviser cette quantité, dans la bonne unité par le débit considéré.
 On obtient:
+\n
     - ADSL à 10Mb/s : 400 000/10 = 40 000 secondes soit un peu plus de 11 heures
     - Fibre à 1 Gb/s : 400/1 = 400 secondes un peu plus de 6 minutes
     - Wifi à 50 Mb/s : un peu plus de 2 heures
     - 3G à 384 Kb/s : 400 000 000/384 soit 1041666 secondes un peu plus de 12 jours
     - 4G à 150 Mb/s : 400 000 / 150 un peu plus de 44 minutes.
+    \n
 Il est donc très rare qu'on échange des vidéos sous le format de ces Blu-ray sur internet et c'est en général des vidéos de moindre qualité qui sont disponibles pour le téléchargement ou la lecture en flux (streaming).
 }
 ```
 
-## Le saviez-vous ? 
+## Le saviez-vous ?
 ### l'ADSL et ses débits
 #### Ça va plus vite dans un sens que dans l'autre
 
@@ -1222,7 +1386,7 @@ ont montré que cette question dépasse largement le cadre Français.
 ####C.B.A \: Le nom de la machine, puis le nom du domaine de 1er niveau et enfin le nom du domaine général. }
 ```
 
-## Le saviez-vous ? 
+## Le saviez-vous ?
 ### Comment la Chine censure internet ?
 
 Le terme **DNS** (*déjà vu dans ce module*) désigne le système (et les machines) qui assurent le service de nommage dans internet, c'est-à-dire l'association entre les *noms de domaine* et adresses *IP*. Les machines qui assurent la distribution de ces informations sont les fameux *serveurs de noms* que nous avons vu précédemment.
@@ -1233,7 +1397,7 @@ Le contrôle du DNS est un enjeu politique fort. Wikipedia relate un exemple de 
 
 À première vue, la mise en place d'un DNS chinois peut prêter à sourire, l'effet le plus directement visible est que certains sites de nom de domaine nom.net.cn sont visibles (sur le réseau internet chinois) avec comme nom nom.net ; l'impact est uniquement visuel et psychologique.
 
-En faisant appel à vos connaissances du fonctionnement d'internet, vous pouvez tout de même remarquer deux conséquences induites par cette action des autorités chinoises : 
+En faisant appel à vos connaissances du fonctionnement d'internet, vous pouvez tout de même remarquer deux conséquences induites par cette action des autorités chinoises :
 
 - il y a dorénavant deux internet. Ou, en d'autres termes, un même nom de domaine ne correspond plus au même service suivant le lieu où l'on se trouve : google.com pourrait correspondre dans une partie du monde à la firme américaine bien connue et en Chine à une autre organisation.
 - La deuxième conséquence est fortement liée à la première. Auparavant, c'est l'organisation *VeriSign* qui contrôlait tous noms de domaine en .com et en .net. À présent certains noms de domaines de cette forme ne demandent plus d'autorisation et ne paient plus de droits à *VeriSign*. C'est donc une perte de pouvoir et une perte de revenus pour VeriSign.
@@ -1244,26 +1408,37 @@ Une petite remarque pour finir. Rappelez-vous que le DNS sert *uniquement* à tr
 ::L'ICANN et la CNIL::
 [markdown]
 Internet n'est pas un monde totalement libre et sans loi comme on pourrait être tenté de le croire. De grands acteurs internationaux et nationaux participent de la régulation d'internet. Nous vous proposons ici d'en découvrir deux.
+\n
 En utilisant les ressources suivantes (et d'autres) :
+\n
     - [http://fr.wikipedia.org/wiki/Domain_Name_System](http://fr.wikipedia.org/wiki/Domain_Name_System)
     - [http://fr.wikipedia.org/wiki/Internet_Corporation_for_Assigned_Names_and_Numbers](http://fr.wikipedia.org/wiki/Internet_Corporation_for_Assigned_Names_and_Numbers)
     - [http://www.cnil.fr/](http://www.cnil.fr/)
     - [http://www.cnil.fr/fileadmin/documents/La_CNIL/publications/CNIL_RA2012_web.pdf](http://www.cnil.fr/fileadmin/documents/La_CNIL/publications/CNIL_RA2012_web.pdf)
+\n
 cherchez les réponses aux questions suivantes :
+\n
 **domaines de premier niveau**
-        - Qu'est un domaine de premier niveau ?
-        - Donnez quelques exemples.
-        - Qui les gère ?
-        - Qu'en pensez-vous ?
+\n
+- Qu'est un domaine de premier niveau ?
+- Donnez quelques exemples.
+- Qui les gère ?
+- Qu'en pensez-vous ?
+\n
 **la CNIL**
-        - Quel est le rôle de la CNIL ?
-        - Avec combien d'employés remplit-elle ses missions ?
-        - Qu'en pensez-vous ?
+\n
+- Quel est le rôle de la CNIL ?
+- Avec combien d'employés remplit-elle ses missions ?
+- Qu'en pensez-vous ?
 {
-####**Domaines de premier niveau**
+####
+**Domaines de premier niveau**
+\n
 Les domaines de premier niveau sont les plus élevés dans la hiérarchie des noms de domaines. Ce sont notamment les domaines identifiants un pays ( `.fr, .de, .uk`...) ou les domaines `.org` pour les organisations et `.com` pour les sites à caractère commercial. Chacun de ces domaines est géré par une organisation propre, mais c'est un organisme unique, *l'ICANN*, qui délègue cette gestion aux autres organismes.
+\n
 **La CNIL**
+\n
 La CNIL (*Commission Nationale de l'Informatique et des Libertés*) est l'instance française chargée de veiller au respect des libertés et de la vie privée sur internet. À ce titre, elle régule notamment l'usage des données personnelles et traces que tout un chacun laisse lorsqu'il utilise internet.
-Au 20 juillet 2013, la CNIL était composée de 17 membres et 174 agents. 
+Au 20 juillet 2013, la CNIL était composée de 17 membres et 174 agents.
 }
 ```

--- a/module2/coursLeWeb.md
+++ b/module2/coursLeWeb.md
@@ -7,13 +7,13 @@ AUTHOR: Culture Numérique
 # Introduction
 
 ## Cours 1/2
-[video]( https://vimeo.com/138623497 ){: .cours_video } 
+[video]( https://vimeo.com/138623497 ){: .cours_video }
 Le web, c'est sans doute l'application informatique qui a rencontré le plus grand succès.
 
 C'est une utilisation particulière  d'internet. Il a été inventé par Tim Berners Lee au début des années 90. C'est d'abord un moyen de communication entre personnes qui permet de s'échanger des informations décrites dans des documents . Il est fréquent de constater une confusion entre Internet et le Web. Or, si le web utilise Internet, il n'est pas la seule application à le faire, le mail par exemple est un autre service qui utilise Internet. Socialement, le web a pris une place considérable dans nos vies. Sur cette application au départ très simple se sont bâties d'autres applications dans tous les domaines d'activités : pour le commerce, le marketing, la recherche d'emploi, le travail à distance et la collaboration... C'est un vecteur important de développement économique aujourd'hui. C'est aussi par des applications web que l'état et les administrations offrent leurs services aux citoyens. C'est encore par les applications sociales du web que nous communiquons dans notre vie privée. Maîtriser les technologies du web est important pour comprendre les enjeux, saisir des opportunités, éviter des pièges... Naviguer sur le web fait aujourd'hui partie du quotidien de chacun d'entre nous. Ce chapitre propose d'en expliquer le fonctionnement pour nous permettre d'avoir des comportements responsables et de garder la maîtrise de ce que nous faisons.
 
 ## Cours 2/2
-[video]( https://vimeo.com/138623515 ){: .cours_video } 
+[video]( https://vimeo.com/138623515 ){: .cours_video }
 
 Alors, qu'est-ce réellement  que le web ? Le Web est avant tout un service qui permet de s'échanger des ressources. Celles-ci peuvent être très variées et prendre de nombreuses formes. Dans un premier temps, nous considérerons pour simplifier que ce sont uniquement des documents qui contiennent soit du texte soit des images.
 Le succès du web est sans doute lié à la notion de document hypertexte. C'est à dire la possibilité d'intégrer à l'intérieur d'un document des liens, qui sont des parties de texte cliquables permettant d'accéder à d'autres ressources.
@@ -57,10 +57,8 @@ L'ensemble des documents ainsi que les liens qui les relient forment alors un r�
       </ol>
     </div>
 {####<p>Contrairement à ce qu'on pourrait imaginer, Tim Berners-Lee n'était pas informaticien mais <b>physicien</b>. Il était chercheur en physique nucléaire au CERN dans les années 80. Son objectif était de faciliter le transfert de connaissance dans la communauté scientifique internationale.</p><p>Le premier site réellement opérationnel décrivait les principales caractéristiques du web et expliquait comment accéder aux documents d'autres personnes et comment configurer son propre serveur.</p><p>Les travaux ont démarré en 1989, le premier site a été mis en ligne en <b>1991</b> mais c'est en 1993 que le premier navigateur au sens ou nous les manipulons aujourd'hui est apparu.</p>}
-```
- 
 
-```activité-avancée
+
 ::Qui dirige le Web ?::[html]
 <p>Le 30 avril 1993, le CERN annonce que le « World Wide Web » sera <b>libre d'utilisation</b> pour tout le monde.</p>
 <div class="editor-indent" style="margin-left: 30px;"><i>Ressources :<br /></i></div>
@@ -113,20 +111,20 @@ Une remarque importante doit être signalée. Le terme naviguer peut prêter à 
 
 ## Les serveurs
 
-**Les serveurs** 
+**Les serveurs**
 [video](https://vimeo.com/138623583){: .cours_video}
 
 Un serveur est un logiciel (un programme) qui s'exécute sur une machine le plus souvent 24/24 et 7/7 et attend qu'un client l'interpelle, par exemple c'est le cas du serveur web www.univ-lille.fr qui distribue les ressources du site de l'université de Lille. Dans ces journaux, de nombreuses informations à propos des clients sont mémorisées : leur adresse IP, des dates de visites, la ressource demandée... Notons que, l'envoi d'une ressource, est en fait l' envoi d'une copie de la ressource, l'original restant disponible pour d'autres requêtes identiques. En plus de ce service de distribution, le serveur garde l' historique de toutes les requêtes qui lui ont été adressées dans des journaux d'activité : les logs en anglais. Ces journaux sont autant de traces que nous laissons et qui peuvent être analysées et exploitées.
-Son rôle est de distribuer les ressources dont il dispose, c'est-à-dire qui sont stockées sur ses disques, aux clients qui les demandent . 
+Son rôle est de distribuer les ressources dont il dispose, c'est-à-dire qui sont stockées sur ses disques, aux clients qui les demandent .
 
 ```compréhension
 
 // question: 268  name: Erreur 404!
 ::Erreur 404!::[html]<p>Que signifie le code d'erreur 404 dans le protocole HTTP</p>{
 	~<p>La ressource a été déplacée sur un autre serveur</p>
-	=<p>La ressource n’existe pas sur le serveur</p>#<p>Votre réponse est correcte.</p> 
+	=<p>La ressource n’existe pas sur le serveur</p>#<p>Votre réponse est correcte.</p>
 	~<p>Le client de peut pas communiquer avec le serveur</p>
-	####<p>L'erreur 404 apparaît lorsque la ressource demandée n'existe pas sur le serveur. Cela se produit en général lorsqu'il y a une 'faute' dans l'url ou lorsque le gestionnaire du site a déplacé, supprimé ou renommé une ressource. L'url devient alors invalide.</p> 
+	####<p>L'erreur 404 apparaît lorsque la ressource demandée n'existe pas sur le serveur. Cela se produit en général lorsqu'il y a une 'faute' dans l'url ou lorsque le gestionnaire du site a déplacé, supprimé ou renommé une ressource. L'url devient alors invalide.</p>
 }
 
 
@@ -136,8 +134,8 @@ Son rôle est de distribuer les ressources dont il dispose, c'est-à-dire qui so
 	~<p>Internet Explorer</p>
 	~<p>Chrome</p>
 	~<p>Safari</p>
-	=<p>Tous</p>#<p>Votre réponse est correcte.</p> 
-	####<p>Tous les navigateurs sont équivalents de ce point de vue, seuls leur rapidité, leurs fonctionnalités avancées ou leur ergonomie les différencient.</p> 
+	=<p>Tous</p>#<p>Votre réponse est correcte.</p>
+	####<p>Tous les navigateurs sont équivalents de ce point de vue, seuls leur rapidité, leurs fonctionnalités avancées ou leur ergonomie les différencient.</p>
 }
 
 
@@ -152,17 +150,17 @@ Son rôle est de distribuer les ressources dont il dispose, c'est-à-dire qui so
 
 // question: 271  name: Les logs c'est quoi ?
 ::Les logs c'est quoi ?::[html]<p>Qu'est-ce qu'un fichier de logs d'un serveur web ?</p>{
-	~la liste des noms des gens qui ont consulté le site hébergé sur le serveur#non, sur la plupart des sites nous n'envoyons pas nos noms, les logs conservent les traces des requêtes effectuées par les clients repérés par leur adresse IP ainsi que toutes les activités du serveur dans un journal 
-	=un journal des activités du serveur#Oui, bravo 
-	~la liste de toutes les ressources stockées sur ce serveur#Non, les logs conservent le journal des activités du serveur 
-	####<p>Voici ci dessous quelques lignes extraites d'un journal (log) d'un serveur Web. Chaque ligne correspond à une requête d'un client. Les lignes ont été "anonymisées" \: nous avons remplacé les adresses IP des clients par 127.0.0.1.  </p><p> </p><p>Sur cette ligne vous avez l'adresse IP (anonymisée) du client, suivi de la date et l'heure de la requête et entre guillemets la requête adressée ("GET /polys/...") qui signifie " donne-moi la ressource "/poly/...etc". On voit également le code 200 signalant que la requête a bien été traitée sans erreur et aussi les caractéristiques du client \:  C'est ici le robot du moteur de recherche bing.</p><p><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:22\:48 +0200] "GET /polys/access-1997/node66.html HTTP/1.1" 200 2257 "-" "Mozilla/5.0 (compatible; bingbot/2.0; +http\://www.bing.com/bingbot.htm)"</code></p><p> </p><p>L'exemple suivant est intéressant car il montre une suite de 5 requêtes. La première est un celle d'un document contenant des liens vers d'autres ressources (feuilles de style CSS et images au format PNG). Les 5 requêtes sont enchaînées car le navigateur (ici Safari) a immédiatement demandé au serveur les ressources nécessaires pour afficher une page web complète.</p><p>    <br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/Football/Confrontations/Ajaccio-Clermont.php HTTP/1.1" 200 4836 "https\://www.google.fr/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" </code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/include/css/ft-v3.css HTTP/1.1" 200 6692 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/include/css/ft-print-v3.css HTTP/1.1" 200 2231 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/Images/valid-html5.png HTTP/1.1" 200 1723 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/Images/FabienTorre.png HTTP/1.1" 200 478 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code></p><p>Un dernier petit exemple pour les hackers \:-). On peut lire avec un peu d'expérience ou de sagacité que la ressource (ici /FAQ-LaTeX/12.3.html) a été demandée depuis une page web (indiquée après le code de succès 200 et la taille de 7444 de cette ressource) qui est une adresse sur les serveurs de Google. En regardant mieux encore, on peut même lire que c'est à la suite d'une recherche à propos de "FAQ-LaTeX"... C'est en partie grâce à cette indication de provenance qu'on peut rémunérer les sites qui font de la publicité vers d'autres sites...</p><p><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:22\:30 +0200] "GET /FAQ-LaTeX/12.3.html HTTP/1.1" 200 7444 "http\://www.google.fr/url?sa\=t&rct\=j&q\=&esrc\=s&source\=web&cd\=1&ved\=0CCQQFjAAahUKEwjo6IWtgIrIAhVFOxQKHdjEDfw&url\=http%3A%2F%2Fwww.grappa.univ-lille3.fr%2FFAQ-LaTeX%2F12.3.html&usg\=AFQjCNEtHaKlFbotxdHj6bxRzpkDN3NwkA" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv\:24.0) Gecko/20100101 Firefox/24.0"</code><br /><br /></p> 
+	~la liste des noms des gens qui ont consulté le site hébergé sur le serveur#non, sur la plupart des sites nous n'envoyons pas nos noms, les logs conservent les traces des requêtes effectuées par les clients repérés par leur adresse IP ainsi que toutes les activités du serveur dans un journal
+	=un journal des activités du serveur#Oui, bravo
+	~la liste de toutes les ressources stockées sur ce serveur#Non, les logs conservent le journal des activités du serveur
+	####<p>Voici ci dessous quelques lignes extraites d'un journal (log) d'un serveur Web. Chaque ligne correspond à une requête d'un client. Les lignes ont été "anonymisées" \: nous avons remplacé les adresses IP des clients par 127.0.0.1.  </p><p> </p><p>Sur cette ligne vous avez l'adresse IP (anonymisée) du client, suivi de la date et l'heure de la requête et entre guillemets la requête adressée ("GET /polys/...") qui signifie " donne-moi la ressource "/poly/...etc". On voit également le code 200 signalant que la requête a bien été traitée sans erreur et aussi les caractéristiques du client \:  C'est ici le robot du moteur de recherche bing.</p><p><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:22\:48 +0200] "GET /polys/access-1997/node66.html HTTP/1.1" 200 2257 "-" "Mozilla/5.0 (compatible; bingbot/2.0; +http\://www.bing.com/bingbot.htm)"</code></p><p> </p><p>L'exemple suivant est intéressant car il montre une suite de 5 requêtes. La première est un celle d'un document contenant des liens vers d'autres ressources (feuilles de style CSS et images au format PNG). Les 5 requêtes sont enchaînées car le navigateur (ici Safari) a immédiatement demandé au serveur les ressources nécessaires pour afficher une page web complète.</p><p>    <br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/Football/Confrontations/Ajaccio-Clermont.php HTTP/1.1" 200 4836 "https\://www.google.fr/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" </code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/include/css/ft-v3.css HTTP/1.1" 200 6692 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/include/css/ft-print-v3.css HTTP/1.1" 200 2231 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/Images/valid-html5.png HTTP/1.1" 200 1723 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:19\:57 +0200] "GET /\~torre/Images/FabienTorre.png HTTP/1.1" 200 478 "http\://www.grappa.univ-lille3.fr/\~torre/Football/Confrontations/Ajaccio-Clermont.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"</code></p><p>Un dernier petit exemple pour les hackers \:-). On peut lire avec un peu d'expérience ou de sagacité que la ressource (ici /FAQ-LaTeX/12.3.html) a été demandée depuis une page web (indiquée après le code de succès 200 et la taille de 7444 de cette ressource) qui est une adresse sur les serveurs de Google. En regardant mieux encore, on peut même lire que c'est à la suite d'une recherche à propos de "FAQ-LaTeX"... C'est en partie grâce à cette indication de provenance qu'on peut rémunérer les sites qui font de la publicité vers d'autres sites...</p><p><br /><code>127.0.0.1 - - [22/Sep/2015\:08\:22\:30 +0200] "GET /FAQ-LaTeX/12.3.html HTTP/1.1" 200 7444 "http\://www.google.fr/url?sa\=t&rct\=j&q\=&esrc\=s&source\=web&cd\=1&ved\=0CCQQFjAAahUKEwjo6IWtgIrIAhVFOxQKHdjEDfw&url\=http%3A%2F%2Fwww.grappa.univ-lille3.fr%2FFAQ-LaTeX%2F12.3.html&usg\=AFQjCNEtHaKlFbotxdHj6bxRzpkDN3NwkA" "Mozilla/5.0 (Windows NT 6.1; WOW64; rv\:24.0) Gecko/20100101 Firefox/24.0"</code><br /><br /></p>
 }
 
 
 // question: 269  name: Les protocoles
 ::Les protocoles::[html]<p>Par quel protocole les clients et serveurs dialoguent-ils ? <br></br></p>{
 	~<p>HTML<br></p>
-	=<p><span style\="font-weight\:normal;"><span style\="font-size\:14.666666666666666px;font-family\:Arial;color\:\#434343;background-color\:transparent;font-weight\:400;font-style\:normal;font-variant\:normal;text-decoration\:none;vertical-align\:baseline;white-space\:pre-wrap;">HTTP</span></span></p>#Votre réponse est correcte. 
+	=<p><span style\="font-weight\:normal;"><span style\="font-size\:14.666666666666666px;font-family\:Arial;color\:\#434343;background-color\:transparent;font-weight\:400;font-style\:normal;font-variant\:normal;text-decoration\:none;vertical-align\:baseline;white-space\:pre-wrap;">HTTP</span></span></p>#Votre réponse est correcte.
 }
 
 
@@ -176,7 +174,7 @@ Son rôle est de distribuer les ressources dont il dispose, c'est-à-dire qui so
 
 
 ## Cours
-[video]( https://vimeo.com/138623678 ){: .cours_video } 
+[video]( https://vimeo.com/138623678 ){: .cours_video }
 ### Exemple
 
 Commençons par un exemple très simple pour comprendre le mécanisme de base. Si à l'aide d'un client web tel que Firefox, je saisis l'adresse :
@@ -189,7 +187,7 @@ Que se passe -t-il ?
 
 Mon client interprète ma saisie comme l'interrogation par le protocole `http` du serveur situé sur la machine `culturenumerique.univ-lille3.fr` pour lui demander la ressource `/PageExemple`
 
-Comme nous l'avons vu précédemment, l'adresse `IP` de ma machine sera nécessaire pour communiquer avec le serveur. Mais mon navigateur va également réunir un certain nombre d'autres informations disponibles sur ma machine (informations que nous verrons plus loin) et les joindre à la requête envoyée au serveur qui héberge la ressource. 
+Comme nous l'avons vu précédemment, l'adresse `IP` de ma machine sera nécessaire pour communiquer avec le serveur. Mais mon navigateur va également réunir un certain nombre d'autres informations disponibles sur ma machine (informations que nous verrons plus loin) et les joindre à la requête envoyée au serveur qui héberge la ressource.
 Le serveur reçoit cette requête, la comprend car elle est formulée selon les règles définies dans ce fameux protocole `http`, norme utilisée pour que les clients web et les serveurs web puissent communiquer.
 
 
@@ -223,7 +221,7 @@ En conclusion, dès que vous transmettez des données confidentielles veillez bi
 	~%33.33333%<p>le protocole utilisé</p>
 	~<p>si la ressource est une image ou un texte</p>
 	~<p>l’adresse du client</p>
-	####<p>URL \: Unified Ressource Locator, soit en français \: l'adresse d'une ressource. Elle contient évidemment \:</p><ul><li>le non du serveur sur laquelle elle est stockée</li><li>le nom de la ressource \: le nom du fichier et le 'chemin' (dossier/sousdossier/) pour y accéder</li><li>le protocole utilisé, pour le Web \: http\:// ou https\://</li></ul><p>Elle ne précise pas le type de la ressource et elle est évidemment indépendante de l'adresse des éventuels clients qui feraient une requête...</p> 
+	####<p>URL \: Unified Ressource Locator, soit en français \: l'adresse d'une ressource. Elle contient évidemment \:</p><ul><li>le non du serveur sur laquelle elle est stockée</li><li>le nom de la ressource \: le nom du fichier et le 'chemin' (dossier/sousdossier/) pour y accéder</li><li>le protocole utilisé, pour le Web \: http\:// ou https\://</li></ul><p>Elle ne précise pas le type de la ressource et elle est évidemment indépendante de l'adresse des éventuels clients qui feraient une requête...</p>
 }
 
 
@@ -232,7 +230,7 @@ En conclusion, dès que vous transmettez des données confidentielles veillez bi
 	~<p>mes communications avec le serveur sont cachées</p>
 	~%50%<p>le contenu de mes communications avec le serveur est crypté</p>
 	~%50%<p>je peux m’assurer que le serveur est celui auquel je veux m’adresser</p>
-	####<p>Le protocole https a 2 fonctions majeures. Il permet \:</p><ul><li>de crypter les échanges (requêtes/réponses) par exemple des mots de passe ou des codes de Carte Banquaire, seul le destinataire pourra les décrypter</li><li>d'authentifier les serveurs, par exemple pour éviter qu'un site pirate cherche à se faire passer pour le site d'une banque</li></ul> 
+	####<p>Le protocole https a 2 fonctions majeures. Il permet \:</p><ul><li>de crypter les échanges (requêtes/réponses) par exemple des mots de passe ou des codes de Carte Banquaire, seul le destinataire pourra les décrypter</li><li>d'authentifier les serveurs, par exemple pour éviter qu'un site pirate cherche à se faire passer pour le site d'une banque</li></ul>
 }
 
 
@@ -250,22 +248,22 @@ En conclusion, dès que vous transmettez des données confidentielles veillez bi
 	~%33.33333%<p>l’adresse IP du client</p>
 	~%33.33333%<p>le nom du navigateur web \: firefox, opera, internet explorer, ….</p>
 	~%33.33333%<p>la page présentée dans le navigateur au moment où la requête est effectuée</p>
-	####<p>l’IP est toujours nécessaire pour indiquer au destinataire à qui il doit répondre. Mais potentiellement les 3 informations peuvent être échangées, et bien d'autres encore !</p> 
+	####<p>l’IP est toujours nécessaire pour indiquer au destinataire à qui il doit répondre. Mais potentiellement les 3 informations peuvent être échangées, et bien d'autres encore !</p>
 }
 
 
 // question: 278  name: Une page web
 ::Une page web::[html]<p>Quand on regarde une page web, toutes les informations viennent du même serveur.</p>{
 	~<p>oui</p><p> </p>
-	=<p>non</p>#<p>Votre réponse est correcte.</p> 
-	####<p>Une page Web est souvent constituée de plusieurs ressources. Chaque ressource fait l'objet d'un échange entre le client et un serveur, pas forcément toujours le même !</p> 
+	=<p>non</p>#<p>Votre réponse est correcte.</p>
+	####<p>Une page Web est souvent constituée de plusieurs ressources. Chaque ressource fait l'objet d'un échange entre le client et un serveur, pas forcément toujours le même !</p>
 }
 
 
 // question: 279  name: Une URL
 ::Une URL::[html]<p>Qu'est-ce qu'une URL ?</p>{
 	~<p>une ressource</p>
-	=<p>l'adresse d'une ressource</p>#<p>Votre réponse est correcte.</p> 
+	=<p>l'adresse d'une ressource</p>#<p>Votre réponse est correcte.</p>
 	~<p>un fichier</p>
 }
 
@@ -275,7 +273,7 @@ En conclusion, dès que vous transmettez des données confidentielles veillez bi
 # HTML
 
 ## HTML: contenu, structure, liens
-[video]( https://vimeo.com/138623721 ){: .cours_video } 
+[video]( https://vimeo.com/138623721 ){: .cours_video }
 Allons maintenant voir plus en détail le fonctionnement ; le langage `html` a plusieurs caractéristiques très intéressantes. Nous avons vu qu'il permettait d'introduire des hyperliens dans un document, mais il possède d'autres atouts.
 
 
@@ -287,7 +285,7 @@ En français la traduction de `html` est : langage de balisage pour documents hy
 Grâce à la description faite du document et en fonction de ses capacités le navigateur va pouvoir recomposer le document et vous l'afficher. Les pages web que votre navigateur affiche sont des textes avec le plus souvent des images, formant un document complet. En fait ce document est réalisé par l'assemblage de nombreuses ressources. En effet, le langage `html` permet également de spécifier l'insertion d'images (ou d'autres ressources) à différents endroits d'un document. Les images ne sont pas à proprement parler insérées dans le document principal, mais un balisage indique qu'à cet endroit il faudra insérer une image.
 
 ## Rassembler les ressources
-[video]( https://vimeo.com/138623756 ){: .cours_video } 
+[video]( https://vimeo.com/138623756 ){: .cours_video }
 
 Rappelons qu'une page affichée dans votre navigateur est en fait un assemblage de nombreuses ressources. Il faut donc dans un premier temps les rassembler.
 
@@ -303,7 +301,7 @@ Cette remarque prendra tout son sens lorsque nous nous intéresserons aux traces
 
 
 ## Mise en forme
-[video]( https://vimeo.com/138623826 ){: .cours_video } 
+[video]( https://vimeo.com/138623826 ){: .cours_video }
 
 Revenons maintenant à l'affichage de la page dans mon navigateur.
 
@@ -365,7 +363,7 @@ Mais une bonne utilisation du traitement de texte passe également par la maîtr
 	~%25%l'alignement du paragraphe
 	~%25%les caractères ont été transformés en majuscule
 	~l'orthographe a été modifié
-	####<p>Une feuille de styles ne peut pas changer l'ordre des mots ou l'orthographe, cela reviendrait à changer le contenu, seules les caractéristiques graphiques sont possibles, ici la police, la couleur, l'alignement et la 'casse' des caractères (ils sont affichés en majuscule).</p> 
+	####<p>Une feuille de styles ne peut pas changer l'ordre des mots ou l'orthographe, cela reviendrait à changer le contenu, seules les caractéristiques graphiques sont possibles, ici la police, la couleur, l'alignement et la 'casse' des caractères (ils sont affichés en majuscule).</p>
 }
 
 
@@ -381,7 +379,7 @@ Mais une bonne utilisation du traitement de texte passe également par la maîtr
 
 // question: 285  name: Structure et contenu
 ::Structure et contenu::[html]<p>Le langage HTML permet de décrire des documents en indiquant leur structure et leur contenu. Comment la structure est-elle décrite ?</p>{
-	=<p>Par un balisage du texte</p>#Votre réponse est correcte. 
+	=<p>Par un balisage du texte</p>#Votre réponse est correcte.
 	~<p>Par des couleurs et du gras ou la taille des caractères</p>
 }
 
@@ -390,12 +388,12 @@ Mais une bonne utilisation du traitement de texte passe également par la maîtr
 ::Une page Web::[html]<p>Pour qu’un client affiche une page Web,...</p>{
 	~<p>une seule requête vers un unique serveur suffit toujours</p>
 	~<p>parfois plusieurs requêtes sont nécessaires mais toujours vers le même serveur</p>
-	=<p>parfois plusieurs requêtes vers plusieurs serveurs sont nécessaires</p>#Votre réponse est correcte. 
+	=<p>parfois plusieurs requêtes vers plusieurs serveurs sont nécessaires</p>#Votre réponse est correcte.
 }
 
 
 // question: 287  name: Expressivité de HTML
-::Expressivité de HTML::[html]<p>Le langage HTML permet de représenter une image.</p>{TRUE#<p>Les images ne sont pas décrites en HTML. HTML ne permet que d'indiquer qu'à un certain endroit dans un document, se trouve une image. 
+::Expressivité de HTML::[html]<p>Le langage HTML permet de représenter une image.</p>{TRUE#<p>Les images ne sont pas décrites en HTML. HTML ne permet que d'indiquer qu'à un certain endroit dans un document, se trouve une image.
 ####[html]En HTML, les images sont représentées dans un format qui leur est propre. Elles sont soit <a href="https://fr.wikipedia.org/wiki/Image_matricielle" target="_blank">matricielles</a> ou <a href="https://fr.wikipedia.org/wiki/Image_vectorielle" target="_blank">vectorielles</a>.</p><ul><li>Les images matricielles décrivent une image comme un assemblage de points de couleur, généralement dans un rectangle de dimensions données par des nombres de points en largeur et en hauteur. Les formats de représentation de ces images matricielles utilisées sur le web sont par exemple le <a href="https://fr.wikipedia.org/wiki/Graphics_Interchange_Format" target="_blank">GIF</a>, le <a href="https://fr.wikipedia.org/wiki/Portable_Network_Graphics" target="_blank">PNG</a>, le <a href="https://fr.wikipedia.org/wiki/JPEG" target="_blank">JPEG</a>.</li><li>Les images vectorielles sont la description d'une image par des formes et des opérations géométriques. Le format <a href="https://fr.wikipedia.org/wiki/Scalable_Vector_Graphics" target="_blank">SVG</a> est utilisé sur le web. Peu d'autres le sont. </li></ul>}
 ```
 
@@ -403,6 +401,7 @@ Mais une bonne utilisation du traitement de texte passe également par la maîtr
 ::Activité sur les serveurs::[markdown]
 Rendez-vous sur la page :
 [pageServeurs.html](http://culturenumerique.univ-lille3.fr/activitesWeb/html/pageServeurs.html)
+\n
 Lisez, observez et répondez aux questions posées...
 {}
 ```
@@ -411,7 +410,7 @@ Lisez, observez et répondez aux questions posées...
 # Les Cookies
 
 ## Cours
-[video](https://vimeo.com/138623890 ){: .cours_video } 
+[video](https://vimeo.com/138623890 ){: .cours_video }
 ### Les cookies, une technique très utile...
 
 Rappelons la conclusion importante du chapitre précédent.
@@ -463,8 +462,8 @@ Si bien que par exemple, le parlement a dû légiférer il y plus de 30 ans pour
 ::Cookie tiers::[html]<p>Un cookie tiers c'est ...</p>{
 	~<p>est un cookie découpé en 3 parties</p>
 	~<p>un cookie partagé entre trois sites</p>
-	=<p>un cookie déposé à la demande d'un serveur qui n'est pas celui de la page web visitée</p>#<p>Votre réponse est correcte.</p> 
-	####<p>Un cookie tiers est bien un cookie qui est déposé sur notre machine par un serveur qui n'est pas celui de la page Web que l'on visite. C'est une technique très souvent utilisée pour l'affichage de publicité ciblée.</p> 
+	=<p>un cookie déposé à la demande d'un serveur qui n'est pas celui de la page web visitée</p>#<p>Votre réponse est correcte.</p>
+	####<p>Un cookie tiers est bien un cookie qui est déposé sur notre machine par un serveur qui n'est pas celui de la page Web que l'on visite. C'est une technique très souvent utilisée pour l'affichage de publicité ciblée.</p>
 }
 
 
@@ -484,7 +483,7 @@ Si bien que par exemple, le parlement a dû légiférer il y plus de 30 ans pour
 // question: 291  name: Un cookie
 ::Un cookie::[html]<p>Un cookie  est une information<br></br></p>{
 	~<p>stockée sur un serveur web à la demande d'un client</p>
-	=<p>stockée sur un client à la demande d'un serveur</p>#Votre réponse est correcte. 
+	=<p>stockée sur un client à la demande d'un serveur</p>#Votre réponse est correcte.
 }
 
 ```
@@ -529,7 +528,7 @@ Notons qu'une pièce jointe fait partie d'un message, il est envoyé avec le cor
 	~<p>les messages comprenant des pièces jointes sont écrits en HTML</p>
 	~%50%<p>les messages écrits en rose sont en HTML</p>
 	~%50%<p>les messages avec des images dans le texte (pas en pièce jointe) ou dans la signature sont en HTML.</p>
-	####<p>Par défaut, les messages électroniques (email) sont écrits en 'texte simple', donc pas en html. Des pièces jointes peuvent être ajoutés au texte. En revanche, dès que le texte est mis en forme (couleur, style, alignement, etc. ) ou qu'une image est insérée dans le corps du message, cela signifie que le mail est en html avec toutes les conséquences vues dans le cours.</p><p>On peut toujours paramétrer son client mail pour ne pas afficher le contenu HTML, évidemment les mises en page seront perdues, ...</p> 
+	####<p>Par défaut, les messages électroniques (email) sont écrits en 'texte simple', donc pas en html. Des pièces jointes peuvent être ajoutés au texte. En revanche, dès que le texte est mis en forme (couleur, style, alignement, etc. ) ou qu'une image est insérée dans le corps du message, cela signifie que le mail est en html avec toutes les conséquences vues dans le cours.</p><p>On peut toujours paramétrer son client mail pour ne pas afficher le contenu HTML, évidemment les mises en page seront perdues, ...</p>
 }
 
 
@@ -538,8 +537,8 @@ Notons qu'une pièce jointe fait partie d'un message, il est envoyé avec le cor
 	~<p>la lecture d'un message écrit en HTML provoque toujours l'envoi de cookies</p>
 	~<p>la lecture de messages en texte (non HTML) peut provoquer l'envoi de cookies</p>
 	~<p>si la lecture d'un message provoque l'envoi de cookies, c'est uniquement vers l'expéditeur du message</p>
-	=<p>Tout est faux</p>#<p>Votre réponse est correcte.</p> 
-	####<p>Tout est faux \: </p><ul><li>la lecture d'un message écrit en HTML peut provoquer l'envoi de cookies ; </li><li>la lecture de messages en texte ne provoque pas l'envoi de cookies, mais il est parfois difficile de discerner un message en simple texte et un message en HTML ! ; </li><li>un expéditeur de message n'est pas un serveur web (même si l'adresse peut être associée un serveur web) et de plus, si la lecture d'un message provoque l'envoi de cookies, ce cookie peut être un cookie tiers et envoyé à n'importe qui.</li></ul> 
+	=<p>Tout est faux</p>#<p>Votre réponse est correcte.</p>
+	####<p>Tout est faux \: </p><ul><li>la lecture d'un message écrit en HTML peut provoquer l'envoi de cookies ; </li><li>la lecture de messages en texte ne provoque pas l'envoi de cookies, mais il est parfois difficile de discerner un message en simple texte et un message en HTML ! ; </li><li>un expéditeur de message n'est pas un serveur web (même si l'adresse peut être associée un serveur web) et de plus, si la lecture d'un message provoque l'envoi de cookies, ce cookie peut être un cookie tiers et envoyé à n'importe qui.</li></ul>
 }
 ```
 
@@ -550,7 +549,7 @@ Votre âge, votre adresse,   vos achats
 récents, vos goûts musicaux, vos films préférés, vos amis, etc,
 toutes ces données peuvent intéresser de nombreuses sociétés et
 organisations soit pour vous surveiller soit pour vous vendre quelque
-chose. Rassemblées, elles contribuent à définir votre /profil/. 
+chose. Rassemblées, elles contribuent à définir votre /profil/.
 
 ### Profils et cookies
 
@@ -602,7 +601,7 @@ Grâce aux cookies contenant des numéros d'identification, des sites ou
  de l'internaute. En fonction des caractéristiques du profil, les
  annonceurs sont prêts à payer plus ou moins cher cet espace. La
  régie organise donc une vente aux enchères de notre profil. Le plus
- généreux remporte le droit d'afficher sa publicité sur notre écran. 
+ généreux remporte le droit d'afficher sa publicité sur notre écran.
 
  Tout cela se déroule de manière automatique grâce à des algorithmes
  sophistiqués en quelques fractions de seconde. Ainsi la page qui
@@ -619,7 +618,7 @@ Grâce aux cookies contenant des numéros d'identification, des sites ou
  illustré, c'est également un moyen de surveillance pour les états, les
  entreprises. C'est un facteur de dissémination de notre vie privée et
  de collecte d'information à notre sujet, parfois,... souvent, à notre
- insu. 
+ insu.
 
  Vous avez maintenant les clés pour comprendre ces questions. Vous
  pouvez en toute connaissance de cause, et c'est bien le droit de
@@ -649,7 +648,7 @@ Grâce aux cookies contenant des numéros d'identification, des sites ou
  web, c'est sûrement sur le plan juridique que la bataille doit avoir
  lieu. Vous êtes maintenant mieux armés pour rejoindre les différentes
  associations d'utilisateurs, ou pour interpeller les élus, participer
- aux débats publics sur les questions de respect de la vie privée. 
+ aux débats publics sur les questions de respect de la vie privée.
 
 ```compréhension
 
@@ -677,9 +676,7 @@ Grâce aux cookies contenant des numéros d'identification, des sites ou
 // question: 295  name: Pister or not pister ?
 ::Pister or not pister ?::[html]<p>Trouvez-vous normal qu'un réseau social piste ses adhérents sans les prévenir ?</p>{}
 
-```
 
-```activité-avancée
 ::Question de loyauté::[html]<p>Écoutez l'enregistrement "Quand nos smartphones sont espionnés" depuis
 <a href="https://interstices.info/jcms/p_83464/quand-nos-smartphones-sont-espionnes">cette page</a>
 puis répondez à la question qui suit.</p>{}
@@ -718,7 +715,7 @@ puis répondez à la question qui suit.</p>{}
  document qui apparaît dans votre navigateur a évidemment été construit
  juste pour vous, au moment de votre demande.
 
-### Un annuaire de toutes les ressources 
+### Un annuaire de toutes les ressources
  Le web est un immense ensemble de ressources reliées entre
  elles. On pouvait imaginer à ses débuts parcourir cet ensemble et
  trouver son chemin vers la ressource souhaitée. On a donc commencé à
@@ -728,13 +725,13 @@ puis répondez à la question qui suit.</p>{}
  a rapidement été abandonné.  La taille du web a grandi tellement vite
  qu'il est devenu impossible de consigner les adresses de toutes les
  ressources, ou même seulement les plus importantes. C'est alors que
- sont entrés en jeu les moteurs de recherche. 
+ sont entrés en jeu les moteurs de recherche.
 
 ###  Comment fonctionne un moteur de recherche aujourd'hui
  Comment fonctionne un moteur de recherche ? C'est à la fois simple
  dans certains principes généraux et complexe pour de nombreux détails
  importants. C'est à la fois connu dans sa généralité et bien caché
- dans ses détails. Nous nous contentons ici de simples généralités. 
+ dans ses détails. Nous nous contentons ici de simples généralités.
 
  Les moteurs de recherche construisent constamment, car le web évolue
  sans cesse, un index. L'index, c'est comme dans un livre, un moyen
@@ -768,7 +765,7 @@ puis répondez à la question qui suit.</p>{}
  les détails de la construction de l'index mais surtout du programme
  qui permet de l'interroger et de la détermination de l'ordre des URLs
  affichées en retour. Ces détails sont protégés par de nombreux secrets
- industriels. 
+ industriels.
 
 ### Collecte de données d'usage
 
@@ -786,14 +783,14 @@ puis répondez à la question qui suit.</p>{}
  données à propos de vos recherche. La tendance actuelle est de rendre
  les réponses personnalisées, ce qui entraîne une collecte de données
  personnelles rendue possible à la fois par les techniques de cookies
- et l'utilisation de comptes chez ces opérateurs de recherche. 
+ et l'utilisation de comptes chez ces opérateurs de recherche.
 
 ### Modèle économique du moteur de recherche
 
  Pour une institution qui veut être visible sur internet, if faut
  assurer sa présence dans l'index. Mais cela n'est pas suffisant : il
  faut être en haut de la liste et donc apparaître important aux yeux du
- moteur de recherche. 
+ moteur de recherche.
 
  De bonnes pratiques en matière de conception de pages web peuvent y
  contribuer. Puisque toute la chaîne de traitement est automatique, les
@@ -803,7 +800,7 @@ puis répondez à la question qui suit.</p>{}
  que dans le but de se faire comprendre de ses lecteurs
  humains. Parfois des conseillers un peu charlatans tentent de se faire
  passer pour des gourous qui vont propulser des sites en première page
- des résultats de recherche. 
+ des résultats de recherche.
 
  Il faut s'en méfier car pour le moteur de recherche, une des premières
  sources de revenu est de vendre ces places. Cela se traduit
@@ -818,18 +815,18 @@ puis répondez à la question qui suit.</p>{}
 
  Cette petite introduction des moteurs de recherche est volontairement
  très succinte et parcellaire. Des éléments techniques essentiels ne
- sont pas mentionnés comme 
+ sont pas mentionnés comme
  - les pré-traitements des textes et la sélection du vocabulaire, le
-   traitement des majuscules, des accents etc... 
+   traitement des majuscules, des accents etc...
  - le calcul du score de pertinence sur lequel repose cet ordre
    d'affichage des réponses, et bien-sûr
  - l'un des algorithmes les plus connus qu'est PageRank utilisé par
-   Google. 
+   Google.
 
  Nous vous invitons à suivre les cours d'option transversale en
  licence, les options de master sur les humanités numériques, ou les
  prochains cours de culture numérique qui aborderont sans doute ces
- questions beaucoup plus précisément. 
+ questions beaucoup plus précisément.
 
 ```compréhension
 
@@ -863,10 +860,6 @@ puis répondez à la question qui suit.</p>{}
 ::neutralité 3::[html]<p>Le gouvernement français travaille sur un projet de loi "<em>pour une République numérique</em>", consultable sur <a href="https://www.republique-numerique.fr" target="_blank">https://www.republique-numerique.fr</a><br></br>Nous vous invitons à enrichir vos connaissances en consultant ce site en détail.</p><p>Testez vos connaissances en répondant aux 14 questions du quizz (<a href="http://www.gouvernement.fr/quiz-le-projet-de-loi-numerique" target="_blank">http://www.gouvernement.fr/quiz-le-projet-de-loi-numerique</a>) et répondez ci-dessous à la question suivante: <strong>quelles sont les deux questions dont les réponses vous ont le plus surpris ?</strong></p>{}
 
 
-```
-
-
-```activité-avancée
 
 ::Attention, l'abus de Google est dangereux pour la planète !::Attention, vous n'avez droit qu'à une seule tentative. Répondez d'abord dans un document séparé, puis collez les réponses dans la zone prévue une fois votre travail terminé.
 
@@ -874,9 +867,7 @@ puis répondez à la question qui suit.</p>{}
 // question: 305  name: Conséquences d'une recherche
 ::Conséquences d'une recherche::[html]<p>Comparez ces deux usages\:</p><p>1. Dans la barre de recherche (ou barre d'URL) je saisis \:<br></br><em>université de lille 3</em><br></br>et ensuite dans la page de résultats affichée je clique sur le lien vers l'université (lien vers http\://www.univ-lille3.fr)</p><p>2. Dans la barre d'URL (attention de ne pas confondre avec la barre de recherche !), je saisis \:<br></br><em>http\://www.univ-lille3.fr</em>.</p><p><strong>Questions</strong>\: Quelles sont les incidences de ces actions dans chacun des cas. Existe-t-il une différence en terme de consommation énergétique, ou de préservation de la vie privée ?</p>{}
 
-```
 
-```activité-avancée
 ::Des moteurs de recherche moins intrusifs...::Attention, vous n'avez droit qu'à une seule tentative. Répondez d'abord dans un document séparé, puis collez les réponses dans la zone prévue une fois votre travail terminé.
 
 
@@ -888,7 +879,7 @@ puis répondez à la question qui suit.</p>{}
 
 # Autres informations sensibles et bilan
 ## Autres informations
-[video]( https://vimeo.com/138623956 ){: .cours_video } 
+[video]( https://vimeo.com/138623956 ){: .cours_video }
 On voit bien que les techniques qui se sont développées et qui continuent d'évoluer sur le Web sont puissantes et nous rendent beaucoup de services. En revanche, leur utilisation dans certains cas peut poser de graves questions de citoyenneté. Bien souvent, la donnée associée au cookie est un numéro d'identification permettant au serveur de retrouver dans ses bases des données propres à l'utilisateur.
 Dans notre exemple de démarche d'inscription, ce pourrait être, l'étape à laquelle il est arrivé, son nom, ses choix de formation...  
 
@@ -900,18 +891,18 @@ Si bien que par exemple, le parlement a dû légiférer il y plus de 30 ans pour
 Naturellement, avec l'avènement du numérique ce rapprochement de numéros d'identification devient très facile techniquement. Il convient de redoubler de vigilance...
 
 ## Bilan: du pour, du contre
-[video]( https://vimeo.com/139925788 ){: .cours_video } 
+[video]( https://vimeo.com/139925788 ){: .cours_video }
 
-Il faut donc avoir conscience que la consultation d'une page laisse des traces sur mon disque dur et sur le réseau. 
+Il faut donc avoir conscience que la consultation d'une page laisse des traces sur mon disque dur et sur le réseau.
 Toutes ces traces peuvent être considérées à divers degrés comme des informations personnelles.
 
 Celles qui résident sur l’ordinateur que vous utilisez, qui peut appartenir à votre employeur, à l’université ou à un cybercafé sont techniquement lisibles par les administrateurs ou les propriétaires de l’ordinateur.
 Les traces qui sont laissées à travers les réseaux, puis sur des serveurs que vous consultez ou des serveurs tiers sont potentiellement exploitables par de nombreux acteurs.
 Il ne s’agit pas de dénoncer ces pratiques comme si elles étaient des malversations.
 
-La mise en cache nous permet de gagner du temps, l’historique est un outil pratique pour rechercher des informations vues récemment, et les cookies sont indispensables au bon fonctionnement d’une très grande quantité de sites. 
+La mise en cache nous permet de gagner du temps, l’historique est un outil pratique pour rechercher des informations vues récemment, et les cookies sont indispensables au bon fonctionnement d’une très grande quantité de sites.
 Par ailleurs, une bonne partie des sites que nous visitons n’existeraient plus si ils n’étaient pas financés par la publicité.
-En revanche, il nous semble important que chacun ait conscience de ce qui se passe. 
+En revanche, il nous semble important que chacun ait conscience de ce qui se passe.
 Aujourd’hui beaucoup croient surfer incognito dès lors qu’on ne voit pas leur écran sans penser qu’un simple clic sur le menu de l’historique peut révéler bien des choses.
 Une infime minorité des internautes a conscience que les pratiques de web-marketing agressives que nous venons de décrire sont abondamment utilisées.
 Une question essentielle dont nous devons tous prendre conscience est celle de la pseudo-gratuité du web :
@@ -924,7 +915,7 @@ Les pratiques de ciblage comportemental vous paraissent-elles légitimes dès lo
 
 On peut tous avoir des avis différents sur ces questions, et chacun devrait être libre de surfer en connaissance de cause.
 Aujourd’hui, pour une bonne part du web, on peut considérer que : “SI C’EST GRATUIT, C’EST QUE LE PRODUIT C’EST VOUS”.
-Vous avez néanmoins la possibilité de choisir les traces que vous êtes prêts à laisser derrière vous. 
+Vous avez néanmoins la possibilité de choisir les traces que vous êtes prêts à laisser derrière vous.
 
 Les activités associées à ce module vont entre autre vous permettre de voir comment paramétrer votre navigateur pour faire vos propres choix.
 
@@ -939,7 +930,7 @@ Les activités associées à ce module vont entre autre vous permettre de voir c
 	~<p>Grâce à l'historique vous pouvez revoir le contenu exact des pages que vous avez visitées récemment</p>
 	~%25%<p>Grâce à l'historique vous pouvez, ré-ouvrir une fenêtre ou un onglet du navigateur récemment fermé</p>
 	~<p>Si une page est dans l'historique, vous pouvez la retrouver dans le cache</p>
-	####<ul><li>Le cache permet d'accélérer l'affichage des pages web  ;</li><li>Si quelqu'un accède à mon ordinateur, il a techniquement la possibilité de connaître les sites web que j'ai récemment visités en regardant le cache et l'historique<br></li><li>Vous pouvez retrouver la liste des sites que vous avez visités récemment dans l'historique. Dans le cache c'est techniquement possible de retrouver de telles informations également.<br></li><li>L'historique permet de ré-ouvrir une fenêtre ou un onglet du navigateur récemment fermé, mais vous ne pouvez pas toujours revoir le contenu exact des pages que vous avez visitées récemment car des données qui s'y trouvent peuvent être calculées en fonction de nombreux paramètres (date, autres visiteurs, etc...) ; <br></li><li>Il est possible qu'une adresse se trouve dans l'historique sans que la page soit stockée dans le cache</li></ul> 
+	####<ul><li>Le cache permet d'accélérer l'affichage des pages web  ;</li><li>Si quelqu'un accède à mon ordinateur, il a techniquement la possibilité de connaître les sites web que j'ai récemment visités en regardant le cache et l'historique<br></li><li>Vous pouvez retrouver la liste des sites que vous avez visités récemment dans l'historique. Dans le cache c'est techniquement possible de retrouver de telles informations également.<br></li><li>L'historique permet de ré-ouvrir une fenêtre ou un onglet du navigateur récemment fermé, mais vous ne pouvez pas toujours revoir le contenu exact des pages que vous avez visitées récemment car des données qui s'y trouvent peuvent être calculées en fonction de nombreux paramètres (date, autres visiteurs, etc...) ; <br></li><li>Il est possible qu'une adresse se trouve dans l'historique sans que la page soit stockée dans le cache</li></ul>
 }
 
 ```
@@ -947,13 +938,10 @@ Les activités associées à ce module vont entre autre vous permettre de voir c
 ```activité-avancée
 ::Vider le cache et l'historique::Faites une capture de la fenêtre du navigateur qui propose de vider le cache et les autres données locales. Déposez-la dans ce devoir.{}
 
-```
 
-```activité-avancée
 ::L'intermédiation: votre analyse::[html]
 <p>Pour terminer ce cours, nous vous proposons de regarder une vidéo d'une présentation par Stéphane Grumbach qui explique les impacts du web et des données numériques d'un point de vue sociétal.</p>
 <p><a target="_blank" class="moz-txt-link-freetext" href="https://www.liglab.fr/evenements/keynote-speeches/stephane-grumbach-leconomie-lintermediation">https://www.liglab.fr/evenements/keynote-speeches/stephane-grumbach-leconomie-lintermediation</a> (1h11mn).</p>
 <p>Citez les éléments dans ce séminaire de Stéphane Grumbach qui vous ont le plus surpris.<em>(Attention, vous n'avez droit qu'à une seule tentative. Cette question est ouverte, répondez d'abord dans un document séparé, puis collez votre réponse dans la zone prévue une fois votre travail terminé.)</em></p>
 {}
 ```
-

--- a/module3/representation.md
+++ b/module3/representation.md
@@ -87,31 +87,26 @@ numérique multimédia.
 ```compréhension
 ::Représenter et manipuler::
 [markdown]
-**Représenter et manipuler**
 Les traitements possibles dépendent fortement des choix de représentation
 {T}
 
 ::Quelles données ?::
 [markdown]
-**Quelles données ?**
 La représentation numérique d'un livre peut inclure des données qui ne se limitent pas au contenu textuel. Donnez quelques exemples.
 {#### Le genre, la date de création, l'éditeur, ...}
 
 ::De la variété ?::
 [markdown]
-**De la variété ?**
 Il n'existe qu'une seule façon de représenter numériquement un livre.
 {F #Représenter une information est le résultat de nombreux choix}
 
 ::Comment choisir ?::
 [markdown]
-**Comment choisir ?**
 Donnez des exemples de critères qui peuvent gouverner le choix d'une représentation numérique.
 {#### la concision, la pertinence (permettre des traitements voulus), l'efficacité (les traitements sont réalisés rapidement, la confidentialité (l'accès aux données  peut être contrôlé),...}
 
 ::Qui choisit ? ::
 [markdown]
-**Qui choisit ?**
 Les choix de représentations sont faits par
 {
 ~Les informaticiens #non pas seuls car intervient aussi l'utilisation métier des objets représentés
@@ -123,8 +118,8 @@ Les choix de représentations sont faits par
 ```activité
 ::Une tâche complexe::
 [markdown]
-**Une tâche complexe**
 Représenter et normaliser est une tâche complexe : l'exemple de HTML. En vous rendant sur les pages wikipedia de [HTML](https://fr.wikipedia.org/wiki/Hypertext_Markup_Language) et du [W3C](https://fr.wikipedia.org/wiki/World_Wide_Web_Consortium). Répondez aux questions suivantes :
+\n
 - Quelle est l'origine de `HTML` ?
 - Qui développe et publie les spécifications `HTML` depuis 1995 ?
 - Quelle est la version la plus récente de `HTML` et son année de parution ?
@@ -244,31 +239,26 @@ structure et les *métadonnées*.
 ```compréhension
 ::Vrai ou Faux : vue séquentielle::
 [markdown]
-**Vrai ou Faux : vue séquentielle**
 Avec la vue séquentielle, on peut remplacer les occurrences d'un mot par un autre mot.
 {T}
 
 ::Vrai ou Faux : vue structurée::
 [markdown]
-**Vrai ou Faux : vue structurée**
 Avec la vue structurée, on peut créer une table des matières automatiquement
 {T}
 
 ::Vrai ou Faux : vue présentation::
 [markdown]
-**Vrai ou Faux : vue présentation**
 Un contenu avec une structure a une seule présentation possible
 {F}
 
 ::La vue qualifiée::
 [markdown]
-**La vue qualifiée**
 Donnez au minimum 4 métadonnées que vous pouvez associer à un livre
 {}
 
 ::Éditeur de textes::
 [markdown]
-**Éditeur de textes**
 Parmi les fonctionnalités suivantes, lesquelles sont possibles ?
 {
 ~%25%copier/couper/coller #tous les éditeurs le permettent
@@ -279,13 +269,14 @@ Parmi les fonctionnalités suivantes, lesquelles sont possibles ?
 }
 
 ::Le jardin zen::
-[markdown] 
-**Le jardin zen**
+[markdown]
 Pour illustrer à la fois la pertinence de séparer les informations de présentation des autres informations textuelles, mais aussi l'effort de la communauté dans cette direction notamment avec les feuilles de style (CSS ou de documents de traitement de textes).  Regardez ces différents liens sur le site la beauté des CSS :
-  - [http://www.csszengarden.com/tr/francais/](http://www.csszengarden.com/tr/francais/)
-  - [http://www.csszengarden.com/tr/fr/221/](http://www.csszengarden.com/tr/fr/221/)
-  - [http://www.csszengarden.com/tr/fr/219/](http://www.csszengarden.com/tr/fr/219/)
-  Entre ces différents designs, qu'est-ce qui change ?
+\n
+- [http://www.csszengarden.com/tr/francais/](http://www.csszengarden.com/tr/francais/)
+- [http://www.csszengarden.com/tr/fr/221/](http://www.csszengarden.com/tr/fr/221/)
+- [http://www.csszengarden.com/tr/fr/219/](http://www.csszengarden.com/tr/fr/219/)
+\n
+Entre ces différents designs, qu'est-ce qui change ?
 {
 ~%0% La structure #non, elle reste la même, vérifiez l'identité des codes HTML avec l'affichage du code (`CTRL-U` sur *PC*, `cmd-U`sur *Mac*)
 ~%0% Le contenu #non, lisez bien, les textes sont les mêmes!
@@ -296,112 +287,127 @@ Pour illustrer à la fois la pertinence de séparer les informations de présent
 ```activité
 ::Installer LibreOffice::
 [markdown]
-**Installer LibreOffice**
-Les activités seront proposées avec le traitement de textes `LibreOffice`. Vous pouvez l'installer depuis le site [http://fr.libreoffice.org/](http://fr.libreoffice.org/). 
-Rappelez-vous que vous devez installer des logiciels depuis les sites officiels uniquement. 
+Les activités seront proposées avec le traitement de textes `LibreOffice`. Vous pouvez l'installer depuis le site [http://fr.libreoffice.org/](http://fr.libreoffice.org/).
+Rappelez-vous que vous devez installer des logiciels depuis les sites officiels uniquement.
 Les activités peuvent aussi être réalisées depuis les salles d'accès libre de l'université où tous les logiciels nécessaires sont disponibles.
 {}
-```
 
-```activité
+
 ::La structure d'un document texte odt::
-[markdown] 
+[markdown]
 **La structure d'un document texte odt**
 Téléchargez le  [document odt](media/representation.odt) sur votre machine. Notez bien l'emplacement où vous l'enregistrez. Lancer `LibreOffice` puis ouvrir le document. Pour explorer sa structure :
+\n
 - Ouvrez le *navigateur de `LibreOffice`* (touche F5). Ici, le mot navigateur ne désigne pas un navigateur Web mais une fonctionnalité fournie par `LibreOffice` pour naviguer dans la structure du document.
 - Dépliez tous les niveaux de titre pour faire apparaître la structure complète des titres du document.
 - Rendre une capture de cette fenêtre de navigateur.
-- Réorganisez la structure : avec le document, déplacez la partie 4.2 en la plaçant juste après la partie 2.2. Pour cela, n'utilisez pas de copier coller mais uniquement les fonctionnalités offertes par l'usage du *navigateur* (touche `F5`). 
+- Réorganisez la structure : avec le document, déplacez la partie 4.2 en la plaçant juste après la partie 2.2. Pour cela, n'utilisez pas de copier coller mais uniquement les fonctionnalités offertes par l'usage du *navigateur* (touche `F5`).
 - Rendre une capture d'écran de la structure obtenue visible dans le *navigateur*.
 - Mettez à jour la **table des matières** qui se trouve en début de document : `clic-droit` dans la partie grisée de la table des matières et sélectionner `Actualiser l'index`.
 {####Voila une première approche de l'utilisation des styles dans un traitement de texte qui permet d'avoir un document structuré. La manipulation que vous venez de faire (déplacement d'une section) illustre l'organisation arborescente du document. Le déplacement d'un noeud déplace en fait toutes les sous-parties de ce noeud. Par ailleurs, la définition de "niveaux de titre" pour certains noeuds de la structure permet la création automatique (et ici la mise à jour automatique) de la table des matières. Cela ne représente qu'une petite partie des possibilités qu'offre une organisation structurée d'un document texte.}
-```
 
-```activité
+
 ::La vue qualifiée d'un document texte odt::
-[markdown] 
-**La vue qualifiée d'un document texte odt**
+[markdown]
 Ouvrir le document [document odt](media/representation.odt) dans `LibreOffice`. Recherchez dans les menus comment trouver les propriétés suivantes :
+\n
 - le titre,
 - le sujet,
 - les mots clef,
 - la date de création.
+\n
 Faites une capture d'écran de la fenêtre où vous avez trouvé ces métadonnées.
 {####Les métadonnées que vous avez trouvées dans cet exercice ont toutes été saisies par une personne. Elles permettent de qualifier le document, de donner des informations sur l'information principale qu'est le contenu. Comme nous l'avons déjà vu avec les éditeurs de texte, les traitements de texte sont aussi capables de**calculer** automatiquement d'autres informations qui dépendent du contenu comme le nombre de mots, de paragraphes ou de signes.}
 
+
 ::Un document peut être réduit à des métadonnées::
 [markdown]
-**Un document peut être réduit à des métadonnées**
 C'est le cas des notices bibliographiques des bibliothèques dont la plus grande partie des fonds n'est pas numérisée. Par conséquent, le contenu des livres n'est pas représenté numériquement et chaque ouvrage est défini par des métadonnées regroupées dans une notice. Nous prenons en exemple le [Catalogue des bibliothèques du SCD de Lille 3](http://hip.scd.univ-lille3.fr/ipac20/ipac.jsp?profile=).
+\n
 - Faites une requête comme, par exemple, `représentation information`
 - Parcourez une ou plusieurs notices des ouvrages en réponse
 - Examinez le contenu de `Sujets` et donnez le rôle de ces métadonnées
 - Indiquez sur quels critères vous pouvez effectuer une recherche.
 {#### les métadonnées dans Sujets sont des concepts ou thèmes associés à l'ouvrage, ils sont produits manuellement par des experts bibliothécaires. Vous pouvez rechercher selon les métadonnées comme les dates, les auteurs, etc. Vous ne pouvez pas faire de recherche plein texte dans l'ensemble du texte d'un livre, sauf éventuellement sur des résumés.}
-```
 
 
-```activité
 ::La structure d'une page web::
 [markdown]
-**La structure d'une page web**
 La structure arborescente est encore plus présente dans les documents au format `HTML`. Les balises sont imbriquées les unes dans les autres et l'ensemble peut être représenté par un arbre. Pour observer cela :
+\n
 - Lancer `Firefox`, rendez-vous sur la [page exemple](http://culturenumerique.univ-lille3.fr/activitesWeb/html).
 - Pressez les touches `CTRL-MAJ-C` (`alt-cmd-C` sur les Mac). La fenêtre de l'inspecteur de code `HTML` s'ouvre.
 - Dans cette fenêtre, observez la structure du document `HTML`. Cliquez sur les petites flèches pour découvrir ou cacher les parties de code `HTML` incluses les unes dans les autres.
 - Sur quelles petites flèches devez-vous cliquer pour arriver au texte *Vous pouvez changer la taille...* ?
-- La liste des balises associées à chacune de ces petites flèches apparaît dans la zone située juste au dessus du code `HTML`. Par exemple, `html>body>section>p`. Elle représente le chemin dans l'arbre associé au document, depuis sa racine jusqu'au texte sélectionné. Sur l'exemple, un paragraphe dans une section dans le corps du document `HTML`. Quel est le chemin pour arriver au texte *Vous pouvez changer la taille...* ?
+- La liste des balises associées à chacune de ces petites flèches apparaît dans la zone située juste au dessus du code `HTML`. Par exemple, `html>body>section>p`. Elle représente le chemin dans l'arbre associé au document, depuis sa racine jusqu'au texte sélectionné. Sur l'exemple, un paragraphe dans une section dans le corps du document `HTML`.
+\n
+Quel est le chemin pour arriver au texte *Vous pouvez changer la taille...* ?
 {####html/body/section/ul/li}
 ```
 
 ```activité-avancée
 ::Mise en forme et structure::
 [markdown]
-**Mise en forme et structure**
-Téléchargez les deux fichiers suivants : 
+Téléchargez les deux fichiers suivants :
+\n
 - [representation1](media/representation1.odt)
-- [representation2](media/representation2.odt). 
+- [representation2](media/representation2.odt).
+\n
 Ouvrez et parcourez ces deux fichiers. Sont-ils identiques ? Qu'est-ce qui les différencie ? Illustrez votre propos en citant des opérations qui seraient plus facilement réalisables avec l'un plutôt qu'avec l'autre et pourquoi.
 {####Les documents semblent identiques, mais les éléments de structure ne sont pas désignés dans le second. Vous ne pouvez pas réaliser de traitements comme : la réorganisation des sections, la génération des tables de matières, etc.
+\n
 Par ailleurs, si vous observez bien, plusieurs défauts majeurs apparaissent dans *representation2.odt* : certains titres se retrouvent isolés en bas de page (p3 et p5), le dernier titre en bleu (page 4) est d'une taille légèrement inférieure aux autre titres en bleu. Ces petites erreurs sont courantes lorsqu'on tente de faire la mise en forme "à la main". Aucune de ces erreurs ne peut se produire dans *représentation1.odt* car les styles des paragraphes prennent en charge entre autre : les veuves et les orphelines (au moins 2 lignes en bas de page ou en haut de page), les titres sont toujours sur la même page que le paragraphe suivant, ce qui évite des titres en bas de page, et les taille, couleur, police, ... choisis sont sélectionnés une seule fois au moment de la définition du style, ce qui signifie qu'AUCUNE différence de forme ne peut intervenir entre 2 paragraphes associés à un même style. La mise en forme de documents longs est donc grandement facilitée par l'utilisation de styles de paragraphe.
+\n
 En résumé : les styles permettent de STRUCTURER le document (génération automatique d'une table des matières, vision en mode plan et facilité de réorganisation), ils sont donc essentiels pour la vue Structurée du document, mais ils sont aussi précieux pour la vue de présentation en faisant gagner beaucoup de temps et en augmentant considérablement la qualité du document. Nous allons illustrer cela dans la suite des activités.}
 
 ::Réutilisation de styles::
 [markdown]
-**Réutilisation de styles**
 Vous avez manipulé jusqu'ici
+\n
 - *representation.odt*, un document structuré utilisant les styles par défaut, toutes les opérations liées à la structure du document sont donc accessibles (cf activité *structure d'un document texte*), mais la mise en forme est très basique.
 - *representation1.odt* qui est lui aussi structuré et dont les styles des différents niveaux de paragraphe ont été modifiés (taille, typo, couleur, alignement, etc).
+\n
 Nous allons maintenant réutiliser les styles définis dans *representation1.odt* pour **modifier la présentation sans modifier la structure** de *representation.odt*. Il existe différentes méthodes pour effectuer cela.
+\n
 Le principe repose sur le fait que les 2 documents utilisent les mêmes noms de styles (les styles par défaut) à savoir :
+\n
 - `Titre`, pour le titre principal du document
 - `sous-titre`, pour le sous-titre
 - `Titre 1`, pour les titres de premier niveau
 - `Titre 2`, pour les titres de deuxième niveau
 - `corps de texte`, pour tous les paragraphes standards
+\n
 Il s'agit donc de demander à `LibreOffice` d'aller chercher les paramètres de présentation de ces différents styles tels qu'ils sont définis dans le document *representation1.odt*. Cela s'effectue en quelques clics ...
+\n
 À vous de faire cette manipulation très simple. Cherchez dans l'interface de `LibreOffice` comment effectuer cette opération. Si vous rencontrez des difficultés, n'hésitez pas à aller dans les salles d'accès libre où la dernière version de `LibreOffice` est installée et où des moniteurs peuvent vous aider.
+\n
 Pensez aussi à utiliser le forum du cours pour poster vos questions ou vos remarques et vous aider mutuellement.
 {}
 
 ::Générer une table des matières::
 [markdown]
-**Générer une table des matières**
 Comme vous avez pu le constater, *representation1.odt* est structuré et il possède une mise en forme des styles, mais la table des matières n'a pas été créée. Vous allez donc la créer maintenant. Les styles des titres ont été paramétrés pour correspondre à des niveaux différents dans la structure arborescente du document. La génération de la table des matières peut donc se faire en 3 clics ...
-Cherchez dans les menus de `LibreOffice` comment insérer une table des matières automatiquement.
-Faites une capture d'écran montrant la table des matières que vous avez créée.
+\n
+- Cherchez dans les menus de `LibreOffice` comment insérer une table des matières automatiquement.
+- Faites une capture d'écran montrant la table des matières que vous avez créée.
 {}
 
 ::Numéroter les paragraphes::
 [markdown]
-**Numéroter les paragraphes**
 Nous allons pour finir utiliser une fonctionnalité qui utilise encore la structure arborescente (avec des niveaux imbriqués) du document. Il s'agit de la numérotation automatique des paragraphes. Chacun des titres (Titre 1 ou Titre 2) correspondant à un niveau, le traitement de texte peut facilement les retrouver et calculer les numéros. Ainsi, à chaque nouvelle partie (Titre 1), la numérotation des sous-parties (Titre 2) recommence à 1.
+\n
 Chercher dans `LibreOffice` comment numéroter automatiquement les parties en utilsant la notation suivante :
+\n
 A / REPRÉSENTER C’EST CHOISIR…
+\n
 B / ANALYSE D'UN DOCUMENT,
+\n
 PLUSIEURS VUES COMPLÉMENTAIRES
+\n
 1 - Introduction
+\n
 2 - Le Contenu, Une Vue Séquentielle
+\n
 etc.
 {}
 ```
@@ -557,7 +563,7 @@ cet accès a de nombreuses conséquences. L'interopérabilité est rendue
 plus difficile : un document dans un format propriétaire, ne peut être
 librement utilisé dans un autre logiciel. La liberté des utilisateurs
 est également atteinte : en échangeant avec un format propriétaire,
-vous forcez vos interlocuteurs à utiliser un logiciel précis. 
+vous forcez vos interlocuteurs à utiliser un logiciel précis.
 
 ![formats ouverts et fermés](media/3_4_format-01.png)
 
@@ -584,7 +590,6 @@ communautaires.
 ```compréhension
 ::Extensions de fichier::
 [markdown]
-**Extensions de fichier**
 Dans le nom de fichier `mondocument.txt`, quelle est l'extension ?
 {####txt}
 
@@ -612,8 +617,7 @@ Un format ouvert facilite l' interopérabilité
 
 ```activité
 ::Format .doc::
-[markdown] 
-**Le format doc**
+[markdown]
 Lisez la page Wikipedia suivante sur [le format doc](https://en.wikipedia.org/wiki/Doc_%28computing%29) et cochez les réponses vraies.
 {~%0% Les fichiers avec l'extension doc désignent  une chose unique. #Non, plusieurs logiciels distincts l'ont utilisé pour stocker la représentation de choses distinctes.
 ~%0% Ce format est ouvert. #Non, c'est un format propriétaire fermé.
@@ -623,8 +627,8 @@ Lisez la page Wikipedia suivante sur [le format doc](https://en.wikipedia.org/wi
 
 ::Format PDF::
 [markdown]
-**Les documents au format PDF**
 Lisez la page Wikipedia sur le [format pdf](https://wikipedia.org/wiki/Portable_Document_Format) et répondez aux questions suivantes
+\n
 - Est-ce un format ouvert ?
 - Peut-on lire et écrire du `pdf` avec des logiciels différents ?
 - Que signifie portable ?
@@ -886,7 +890,6 @@ Quel est le **point de codage Unicode** du *point d'exclamation* (!) et son nom 
 
 ::Caractère informatique, caractère et glyphe::
 [markdown]
-**Caractère informatique, caractère et glyphe**
 En informatique le caractère est un peu différent du caractère en typographie...
 {~%30%Le caractère informatique est une notion abstraite pour désigner un symbole d'écriture. # oui
 ~%30%Le caractère informatique peut être invisible. #oui
@@ -896,7 +899,6 @@ En informatique le caractère est un peu différent du caractère en typographie
 
 ::Caractères sans glyphe::
 [markdown]
-**Caractères sans glyphe**
 Donner des exemples de caractères non imprimables
 {####l'espace bien-sûr, mais aussi le retour à la ligne, la fin de fichier, la tabulation,...}
 
@@ -905,15 +907,15 @@ Donner des exemples de caractères non imprimables
 ```activité
 ::Autres codes -- Un code mécanisé::
 [markdown]
-**Autres codes -- Un code mécanisé**
+\n
 - Que permettait de représenter le [code Baudot](https://fr.wikipedia.org/wiki/Code_Baudot) ?
 - Pourquoi aujourd'hui ce *code Baudot* n'est plus utilisé pour représenter les caractères?
-{####32 caractères uniquement : les lettres, les chiffres, la ponctuation, et quelques autres symboles (=, +, -, /, *, &, #...) ; 
+{####32 caractères uniquement : les lettres, les chiffres, la ponctuation, et quelques autres symboles (=, +, -, /, *, &, #...) ;
 Les symboles des langues autres que l'américain ne peuvent être représentés.}
 
 ::Autres codes -- un code par le signal::
 [markdown]
-**Autres codes -- un code par le signal**
+\n
 - Que permet de représenter le [code Morse](https://fr.wikipedia.org/wiki/Morse_%28alphabet%29)
 - Ce code est basé sur des impulsions et des silences. Quels sont-ils ?
 - Trouver pour quelle raison la lettre `E` a le plus court codage ?
@@ -922,6 +924,7 @@ Les symboles des langues autres que l'américain ne peuvent être représentés.
 ::Unicode actu::
 [markdown]
 Rendez vous sur le [site Unicode](http://www.unicode.org/).
+\n
 - Allez dans le menu *Proposed Changes -- Proposed Characters*. Vous y verrez des caractères en attente d'intégration dans le standard.
 - Allez dans le menu *The Consortium -- Who we are*. Constatez la diversité du consortium et de son organisation.
 - Regardez les [caractères actuels](http://www.unicode.org/charts/).
@@ -930,26 +933,25 @@ Rendez vous sur le [site Unicode](http://www.unicode.org/).
 
 ::Codage des caractères dans les pages Web::
 [markdown]
-**Déclaration du codage des caractères dans les pages Web**
 Les caractères sont représentés conformément au standard `Unicode` et au codage `UTF-8` pour 80% des pages Web.
+\n
 - Ouvrez la [page suivante](media/pageSansDeclaration.html) puis ensuite cette [autre page](media/pageAvecEncodage.html)
 - Que constatez-vous ?
-- Consultez les codes sources de ces deux pages (utilisez la séquence de touches `CTRL-U` ou  `cmd-U` sur Mac pour l'obtenir) et voyez la différence. Recopiez la ligne qui déclare cet encodage du jeu de caractères. 
+- Consultez les codes sources de ces deux pages (utilisez la séquence de touches `CTRL-U` ou  `cmd-U` sur Mac pour l'obtenir) et voyez la différence. Recopiez la ligne qui déclare cet encodage du jeu de caractères.
 {#### =<meta charset="utf-8">=. Ici =meta= signifie métadonnée, c'est-à-dire information à propos de ce document, =charset= est une contraction pour signifier jeu (ou ensemble) de caractères, et bien-sûr =UTF-8= spécifie l'encodage choisi.}
-```
 
-```activité
+
 ::Structure implicite::
 [markdown]
-**Structure implicite**
 Ouvrir le [fichier suivant](media/representation.txt) avec un éditeur de texte. Modifiez  la taille de la fenêtre de l'éditeur en l'agrandissant ou la réduisant. Quelles observations vous permettent de vérifier  que le paragraphe est bien un élément de structure et que la ligne n'est pas un élément de structure ?
 {#### Les paragraphes marqués par un passage à la ligne restent séparés alors que les lignes varient selon la taille de la fenêtre}
 
 ::Compter les mots::
 [markdown]
-**Compter les mots**
-On considère le texte suivant : 
+On considère le texte suivant :
+\n
 *Bonjour l'ami. Soyez curieux bien-sûr ; essayez-donc ! Signé : marc.latour@yahoo.com*
+\n
 - Comptez le nombre de mots.
 - Saisissez le texte dans LibreOffice et, dans le bas de la fenêtre le logiciel de traitement de textes vous indique le nombre de mots du document ou d'une sélection. Qu'observez-vous pour le texte et pour les parties de textes quant au nombre de mots ? Est-ce le résultat auquel vous vous attendiez ?
 - Effectuez la même opération dans un éditeur de textes et posez vous les mêmes questions. Vous chercherez dans les différents menus comment obtenir les statistiques du texte qui indiquent le nombre de mots.
@@ -959,8 +961,8 @@ On considère le texte suivant :
 ```activité-avancée
 ::Les paragraphes, structure explicite::
 [markdown]
-**Les paragraphes, structure explicite**
 Dans un traitement de textes, la notion de paragraphe est explicite. Il existe un caractère informatique signifiant fin de paragraphe et l'utilisateur l'insère explicitement dans un texte en appuyant sur la touche `Entrée`. L'appui sur la combinaison `MAJ-Entrée` insère elle une fin de ligne, mais sans pour autant changer de paragraphe. À vous de constater cela dans votre traitement de textes :
+\n
 - Dans un nouveau document saisissez un très long texte. N'utilisez qu'une seule fois la touche entrée pour signifier que ce long texte est composé de deux paragraphes.
 - Dans les options de mise en forme des paragraphes centrez le premier. Vérifiez que le second n'est pas centré.
 - Au milieu du second, appuyez sur `MAJ-Entrée` pour retourner à la ligne. Dans les options de mise en forme des paragraphes alignez le second paragraphe à droite. Vérifiez que la mise en forme s'applique, y compris après le retour à la ligne.
@@ -968,8 +970,8 @@ Dans un traitement de textes, la notion de paragraphe est explicite. Il existe u
 
 ::codage des points de codage -- UTF-8 et UTF-16::
 [markdown]
-**codage des points de codage -- UTF-8 et UTF-16**
 Le standard Unicode associe à tout caractère pris en charge par Unicode un nom et un numéro appelé son point de codage. Ce point de codage est un nombre entier qu'il faut encore coder en langage machine, c'est-à-dire avec les seuls symboles 0 et 1 qu'on regroupe dans des suites de huit symboles appelés octets. Rendez vous sur la page [wikipedia UTF-8](https://fr.wikipedia.org/wiki/UTF-8). Lisez le texte en répondant aux questions suivantes :
+\n
 - Combien peut-on coder de caractères avec `UTF-8` ?
 - Est-ce que tous les caractères sont codées sur le même nombre d'octets ?
 - Le A a pour nom "LatinCapital Letter A" et pour point de codage 65. Sur combien d'octets est-il codé ? Donner son code binaire.
@@ -977,13 +979,13 @@ Le standard Unicode associe à tout caractère pris en charge par Unicode un nom
 - Donnez des caractères usuels en écriture française qui ne sont pas codés sur un seul octet
 - Si un octet commence par 0, on peut dire que cet octet code un caractère. Si un octet commence par 110, combien faut-il prendre d'octets ? Avec 1110 ? Avec 11110 ?
 {#### supérieur à 1 million ; Non de 1 à 4 octets ; sur 1 octet 01000001 ; les lettres minuscules, majuscules, ponctuations ; les lettres accentuées, le c cédille, le e dans l'o ; 110 deux octets, 1110 trois octets, 11110 4 octets}
-```
 
-```activité-avancée
+
 ::Exemple de html::
 [markdown]
 **HTML**
 Le HTML est un langage très simple à apprendre. Vous pouvez réaliser quelques essais mineurs avec cet exercice. Respectez bien l'imbrication des balises pour que l'ensemble forme bien un bon arbre. Pour aller plus loin, suivez les cours d'option informatique métiers du web ou lisez les nombreux tutoriels sur internet.
+\n
 - Ouvrez le fichier [html.html](media/html.html).
 - Essayez d'ajouter un paragraphe, un titre de niveau 2.
 - Pour les plus aguerris ajoutez une liste avec les balises `<ul><li>élément</li></ul>`.
@@ -993,7 +995,9 @@ Le HTML est un langage très simple à apprendre. Vous pouvez réaliser quelques
 [markdown]
 **Markdown**
 Un autre langage de description de texte est particulièrement utilisé, il s'agit de `Markdown`. Pour information, le cours que vous suivez a été entièrement rédigé avec cette syntaxe. Nous vous proposons de le découvrir en passant par un site qui permet d'écrire du texte en `markdown`et qui en propose un rendu en html ou des exports dans différents formats.  Ouvrez le fichier [markdown.html](media/markdown.html).
+\n
 En observant cet exemple, trouvez ` comment en  `Markdown` :
+\n
 - mettre des mots en italique ?
 - mettre des mots en gras ?
 - définir un titre de premier niveau ?
@@ -1005,17 +1009,14 @@ En observant cet exemple, trouvez ` comment en  `Markdown` :
 
 ::LaTeX::
 [markdown]
-**LaTeX**
-Enfin, le format de représentation numérique de documents scientifiques, qui permet de générer de textes de très grande qualité typographique est LaTeX. (Voyez par exemple le site [arXiv](http://www.arxiv.org) et les [formats de soumission d'articles autorisés](https://arxiv.org/help/submit#text)). Ici encore, c'est un langage structuré et on peut le comprendre de cette façon. À titre d'exemple, regardez le [document suivant](media/exempleLaTeX.tex) avec un éditeur de textes (bloc-note, textEdit, gedit, selon votre ordinateur) ainsi que son [rendu en PDF](media/exempleLaTeX.pdf). Quelles commandes permettent de structurer les parties de document ? 
+Enfin, le format de représentation numérique de documents scientifiques, qui permet de générer de textes de très grande qualité typographique est LaTeX. (Voyez par exemple le site [arXiv](http://www.arxiv.org) et les [formats de soumission d'articles autorisés](https://arxiv.org/help/submit#text)). Ici encore, c'est un langage structuré et on peut le comprendre de cette façon. À titre d'exemple, regardez le [document suivant](media/exempleLaTeX.tex) avec un éditeur de textes (bloc-note, textEdit, gedit, selon votre ordinateur) ainsi que son [rendu en PDF](media/exempleLaTeX.pdf).
+\n
+Quelles commandes permettent de structurer les parties de document ?
 {####Ce sont les instructions \section et \subsection. Si vous êtes curieux, vous pouvez essayer LaTeX de manière collaborative sur [ShareLaTeX](https://fr.sharelatex.com/) ou sur [Overleaf](https://www.overleaf.com)}
-```
 
 
-
-```activité-avancée
 ::Règles de typographie::
 [markdown]
-**Règles de typographie**
 Lorsque vous utilisez un logiciel comme `LateX`, vous spécifiez la structure du document et certains éléments de mise en forme. C'est le programme qui respecte les règles de l'édition scientifique pour générer le document imprimable : taille des espaces, sauts de ligne, césure des mots, sauts de page, placement des figures, ... Cependant, il reste à votre charge de connaître et respecter certaines régles typographiques minimales comme espace après la virgule, espace avant et après le point-virgule (seulement après en anglais). Voici un document sur les [bonnes pratiques de typographie](http://www.ebooksgratuits.com/guides/typographie.pdf).
 {}
 ```
@@ -1097,7 +1098,7 @@ perte de qualité. L'affichage est *recalculé* quel que soit le niveau
 de zoom. Il est également très facile de modifier un élément de
 l'image indépendamment des autres. Notons que le même
 type de représentation est utilisé pour représenter des images en 3
-dimensions. Pour terminer, les langages de description d'images vectorielles sont également étendus pour intégrer des animations et des interactions. Beaucoup de jeux vidéos, notamment ceux intégrés dans le navigateur web utilisent ces images animées vectorielles. 
+dimensions. Pour terminer, les langages de description d'images vectorielles sont également étendus pour intégrer des animations et des interactions. Beaucoup de jeux vidéos, notamment ceux intégrés dans le navigateur web utilisent ces images animées vectorielles.
 
 
 ### Les images matricielles
@@ -1203,10 +1204,9 @@ Je veux représenter une carte routière. Je dispose des relevés des positions 
 
 ::Une capture d'écran::
 [markdown]
-**Une capture d'écran**
 Je réalise une capture d'écran. À votre avis l'image générée est plutôt :
 {
-=une image matricielle. #Oui, l'écran est déjà une matrice de points, et on veut une représentation fidèle de cette image, non abstraite. 
+=une image matricielle. #Oui, l'écran est déjà une matrice de points, et on veut une représentation fidèle de cette image, non abstraite.
 ~une image vectorielle #Non, imaginez que l'écran affiche une photographie, on ne peut pas trouver des figures géométriques partout dans cette image.
 }
 ```
@@ -1214,66 +1214,66 @@ Je réalise une capture d'écran. À votre avis l'image générée est plutôt :
 ```activité
 ::Échantillonner les images::
 [markdown]
-**Échantillonner les images**
 Plusieurs  appareils photo sont équipés d'une cellule qui permet de capturer les image sur une grille de 4000 par 3000. Dans les notices, il est indiqué alors combien de mégapixels (millions de pixels) ?
 {####12 Mégapixels. Voyez le tableau https://fr.wikipedia.org/wiki/Capteur_photographique#Capteurs_utilis.C3.A9s_dans_les_appareils_photographiques_num.C3.A9riques}
 
 ::La qualité de l'image::
 [markdown]
 **Qualité et résolution**
-La qualité d'une image imprimée va dépendre du nombre de pixels, mais aussi de la taille de ces pixels. Vous avez sans doute remarqué que la qualité d'un agrandissement photo peut être parfois dégradé par rapport à un original de taille plus réduite. Des unités mesurent cette finesse des images, appelée encore la résolution. Cherchez sur internet les unités utilisées pour indiquer la résolution des images. 
+La qualité d'une image imprimée va dépendre du nombre de pixels, mais aussi de la taille de ces pixels. Vous avez sans doute remarqué que la qualité d'un agrandissement photo peut être parfois dégradé par rapport à un original de taille plus réduite. Des unités mesurent cette finesse des images, appelée encore la résolution. Cherchez sur internet les unités utilisées pour indiquer la résolution des images.
+\n
 *Aide* : l'influence anglo-saxonne est bien présente, le pouce (inch) est utilisé.
 {####ppp (ppi) pour point par pouce (point per inch) ou dpi (dot per inch) }
 
 ::Échantillonner la musique::
 [markdown]
-**Échantillonner la musique**
 Un CD contient une représentation numérique standardisée de la musique. Dans ce cas,  on prend une mesure de la valeur du son plusieurs milliers de fois par seconde. Les milliers de fois par seconde se disent  *kilo hertz* (Khz). Quelle est la valeur de l'échantillonnage utilisée dans le format des CD audio ?
 {#### 44,1Khz, c'est-à-dire qu'on mesure le son 44 100 fois par seconde.}
-```
 
-```activité
+
 ::Les valeurs de Rouge de Vert ou de Bleu::
 [markdown]
-**Les valeurs de Rouge de Vert ou de Bleu**
 Pour chaque pixel, échantillon spacial de l'image, une valeur de couleur est mémorisée. La qualité de l'image dépend à la fois du nombre et la taille des pixels, mais également de la précision de cette mesure de couleur. Très souvent, chaque proportion de rouge, vert et bleu est stockée chacune sur un octet. Mais combien de valeurs possibles peut-on représenter avec un octet ?
-{####256, Voir https://fr.wikipedia.org/wiki/Octet. 
-- Avec un bit, deux valeurs (0 et 1) peuvent être codées ; 
-- avec 2 bits, 4 valeurs (00,01,10,11) ; 
+{####256, Voir https://fr.wikipedia.org/wiki/Octet.\n
+  \n
+- Avec un bit, deux valeurs (0 et 1) peuvent être codées ;
+- avec 2 bits, 4 valeurs (00,01,10,11) ;
 - avec 3 bits, 8 valeurs (000,001,010,011, 100,101,110,111),
-- ... 
+- ...
 - avec 8 bits, on obtient 256 valeurs possibles.}
 
 ::Les valeurs RVB::
 [markdown]
-**Les valeurs RVB**
-Avec 1 octet par couleur primaire : 
-- combien d'octets sont nécessaires pour coder une couleur dans le système RVB (Rouge Vert Bleu) 
+Avec 1 octet par couleur primaire :
+\n
+- combien d'octets sont nécessaires pour coder une couleur dans le système RVB (Rouge Vert Bleu)
 - Combien de couleurs différentes peuvent être codées ?
 {####1 octet par couleur, 3 couleurs, donc 3 octets, donc 256*256*256=16 777 216 valeurs possibles. Soit environ 16 millions.}
-```
 
-```activité
+
 ::Pierre Bézier::
 [markdown]
+\n
 - Qui est *Pierre Bézier* ?
 - Qu'a-t-il inventé ?
 {}
 
 ::Courbe de Bézier::
 [markdown]
-Il est possible de définir des courbes avec peu d'informations. Par exemple, une *courbe de Bézier cubique* est définie par la donnée de 4 points A, B, C et D. 
-- A est le point de départ, 
-- AB donne la direction initiale, 
-- D est le point d'arrivée et 
-- CD donne la direction d'arrivée et le reste ce sont des mathématiques. Notez que B et C donnent des directions et que la courbe ne passe pas par B et C. Vous pouvez voir des animations de construction de courbe sur la page [courbe de Bézier](https://fr.wikipedia.org/wiki/Courbe_de_B%C3%A9zier) et lire la section Applications de cette page.
+Il est possible de définir des courbes avec peu d'informations. Par exemple, une *courbe de Bézier cubique* est définie par la donnée de 4 points A, B, C et D.
+\n
+- A est le point de départ,
+- AB donne la direction initiale,
+- D est le point d'arrivée et
+- CD donne la direction d'arrivée et le reste ce sont des mathématiques. Notez que B et C donnent des directions et que la courbe ne passe pas par B et C.
+\n
+Vous pouvez voir des animations de construction de courbe sur la page [courbe de Bézier](https://fr.wikipedia.org/wiki/Courbe_de_B%C3%A9zier) et lire la section Applications de cette page.
 {}
 ```
 
 ```activité-avancée
 ::métadonnées de photos::
 [markdown]
-**Métadonnées de photos**
 La plupart des appareils photos numériques ajoutent des métadonnées à chaque prise de vue.  Des standards comme EXIF ou IPTC existent pour les représenter. Recherchez des exemples de métadonnées associées aux photos.
 {####Elles
 peuvent décrire les caractéristiques techniques de la prise de vue
@@ -1285,15 +1285,14 @@ Mais aussi les personnages ou les étiquettes associées à la photo ...}
 
 ::manipulations images SVG::
 [markdown]
-**Manipulations d'images SVG**
 Vous pouvez vous initier à la définition d'images vectorielles avec le standard `SVG` avec [cette page](media/svg.html). Essayez donc de changer l'épaisseur de la ligne rouge, la position du rectangle bleu, le rayon du cercle jaune. Et si vous  êtes forts ajoutez une nouvelle ligne verte horizontale!
 {}
 
 ::Les images CMJN::
 [markdown]
-**Les images CMJN**
-Un autre modèle de couleur est utilisé dans le monde de l'édition, il s'agit du modèle `CMJN`. Le principe est similaire au modèle RVB, il s'agit de décrire une couleur par combinaison de plusieurs couleurs primaires. Mais alors que le RVB
-correspond aux technologies des écrans, le CMJN est adapté au monde de l'impression. Que signifient les initiales CMJN ?
+Un autre modèle de couleur est utilisé dans le monde de l'édition, il s'agit du modèle `CMJN`. Le principe est similaire au modèle RVB, il s'agit de décrire une couleur par combinaison de plusieurs couleurs primaires. Mais alors que le RVB correspond aux technologies des écrans, le CMJN est adapté au monde de l'impression.
+\n
+Que signifient les initiales CMJN ?
 {#### Cyan Magenta Jaune et Noir, en anglais : CMYB pour Cyan, Magenta, Yellow et blacK}
 ```
 
@@ -1342,5 +1341,3 @@ mouvement qui impacte aujourd'hui toute la société numérique.
 {#### la liberté d'utiliser le logiciel, pour quelque usage que ce soit ;  la liberté d'étudier le fonctionnement du programme, et de l'adapter à vos propres besoins ; la liberté de redistribuer des copies de façon à pouvoir aider votre voisin ; la liberté d'améliorer le programme, et de diffuser vos améliorations au public, de façon à ce que l'ensemble de la communauté en tire avantage. (L'accès au code source est une condition pour tout ceci)
 }
 ```
-
-

--- a/module4/traitementsDeTexteTableur.md
+++ b/module4/traitementsDeTexteTableur.md
@@ -940,7 +940,7 @@ réaliser une sélection, on doit :
 ```Activité avancée
 
 ::Tri et filtres::
-En utilisant le [classeur à propos des associations](./media/association.ods),  vous pourrez trier par ordre alphabétique des noms. Puis trier par ordre croissant des âges et noter que l'ordre alphabétique est perdu ! Puis trier par tranche d'âge en triant chaque tranche d'âge par âge croissant. Des exemples de filtres à réaliser sont :\n
+En utilisant le [classeur à propos des associations](./media/association.ods),  vous pourrez trier par ordre alphabétique des noms. Puis trier par ordre croissant des âges et noter que l'ordre alphabétique est perdu ! Puis trier par tranche d'âge en triant chaque tranche d'âge par âge croissant. Des exemples de filtres à réaliser sont :
 \n
 1. Sélectionner les juniors ;
 2. Sélectionner les juniors femmes ;

--- a/module4/traitementsDeTexteTableur.md
+++ b/module4/traitementsDeTexteTableur.md
@@ -895,7 +895,7 @@ modifier les contenus de ces cellules sans changer les formules pour que les ré
 [markdown]
 Dans ce dans le classeur [Premières formules](./media/premieresformules.ods) qui contient deux feuilles de calculs, vous vous entraînerez à écrire des formules avec des additions, des multiplications et la fonction `SOMME()`.  {}
 
-
+::Fonction SI::
 Entraînez-vous maintenant avec la [fonction SI](./media/fonctionSI.ods).  {}
 ```
 

--- a/module4/traitementsDeTexteTableur.md
+++ b/module4/traitementsDeTexteTableur.md
@@ -268,6 +268,7 @@ Chaque élément de liste est un paragraphe. On active la structure de
 ::Refaire la saisie::
 [markdown]
 Reproduire l'exemple de cette vidéo [La saisie](https://owncloud.univ-lille3.fr/index.php/s/mI7DtCQqsFWhLqn){: .lien_video }. Une partie du texte est disponible en suivant ce [lien](./media/MonPremierPas-Master.txt).
+\n
 Enregistrer votre travail dans un fichier que vous déposerez sur votre compte *Owncloud*. Récupérez le lien de ce fichier et collez-le dans la zone de texte de cette activité.{}
 
 ```
@@ -392,7 +393,7 @@ Si vous respectez ces règles, alors le logiciel va pouvoir calculer la
 ```Activité
 Revoir la formulation Avec le texte de la charte copié selon la méthode de votre choix,préparez un [document mis en forme](./media/Charte.pdf).
 
-> Remplacez le texte *En aucun cas les membres de l'université ne vous réclameront votre identifiant et / ou votre mot de passe* pour le passer en minuscules avec `MAJ-F3`. Appliquer les déclarations d'accentuation, les titres, les listes. Choisissez un affichage avec petites majuscules pour l'accentuation forte.
+Remplacez le texte *En aucun cas les membres de l'université ne vous réclameront votre identifiant et / ou votre mot de passe* pour le passer en minuscules avec `MAJ-F3`. Appliquer les déclarations d'accentuation, les titres, les listes. Choisissez un affichage avec petites majuscules pour l'accentuation forte.
 
 Le haut de page reprend le titre déclaré dans les méta-données. Les lignes horizontales sont des bordures. Les titres sont bien de bon niveau (titre principal et titre de niveau 1). Enregistrer votre travail dans un fichier que vous déposerez sur votre compte owncloud. Récupérez le lien de ce fichier et collez-le dans la zone de texte de cette activité.{}
 ```
@@ -473,6 +474,7 @@ ici. Par exemple, nous ajoutons une espace après chaque numéro.
 ::exercice de styles::
 [markdown]
 Reproduire le document dont un pdf vous est donné [ici](./media/texte_final.pdf). Aucune mise en forme directe n'est tolérée ! Dans ce document, nous avons utilisé des styles spécifiques pour désigner les personnes et les œuvres, le résumé et les citations ; nous avons 3 styles de page avec des numérotations en romain pour les pages d'index et de tables ; nous avons utilisé les guillemets et les listes françaises. La police de caractère est sans doute différente sur votre machine. Ici ce sont les polices Latin Modern Roman et Latin Modern Sans pour les versions avec et sans serif. Vous pouvez prendre celles de votre choix. Bien-sûr tous les principes expliqués dans ce cours ont été appliqués.
+\n
 Enregistrer votre travail dans un fichier que vous déposerez sur votre compte *Owncloud*. Récupérez le lien de ce fichier et collez-le dans la zone de texte de cette activité. {}
 
 
@@ -572,11 +574,13 @@ Voici quelques activités que nous vous proposons pour découvrir d'autres fonct
 ::ajouter des images::
 [markdown]
 Ajouter des images ([image1 "image styles"](./media/styles.png), [image2 "image style général"](./media/styleGeneral.png)) dans un cadre avec une légende pour construire les illustrations du cours.
+\n
 Enregistrer votre travail dans un fichier que vous déposerez sur votre compte *Owncloud*. Récupérez le lien de ce fichier et collez-le dans la zone de texte de cette activité.{}
 
 ::Utiliser un modèle::
 [markdown]
 Reprendre le document de la charte graphique et appliquer le modèle donné [ici](./media/ModeleCN.ott).
+\n
 Enregistrer votre travail dans un fichier que vous déposerez sur votre compte *Owncloud*. Récupérez le lien de ce fichier et collez-le dans la zone de texte de cette activité.{}
 
 ```
@@ -936,7 +940,8 @@ réaliser une sélection, on doit :
 ```Activité avancée
 
 ::Tri et filtres::
-En utilisant le [classeur à propos des associations](./media/association.ods),  vous pourrez trier par ordre alphabétique des noms. Puis trier par ordre croissant des âges et noter que l'ordre alphabétique est perdu ! Puis trier par tranche d'âge en triant chaque tranche d'âge par âge croissant. Des exemples de filtres à réaliser sont :
+En utilisant le [classeur à propos des associations](./media/association.ods),  vous pourrez trier par ordre alphabétique des noms. Puis trier par ordre croissant des âges et noter que l'ordre alphabétique est perdu ! Puis trier par tranche d'âge en triant chaque tranche d'âge par âge croissant. Des exemples de filtres à réaliser sont :\n
+\n
 1. Sélectionner les juniors ;
 2. Sélectionner les juniors femmes ;
 3. Sélectionner les membres qui ne sont pas à jour de leur cotisation, ... {}
@@ -955,4 +960,3 @@ de diagramme est important car il précise ce message :
 - Pour les données dans de nombreuses dimensions : les radars.
 
 Rappelez-vous donc qu'on ne représente pas pour faire beau mais pour informer.
-


### PR DESCRIPTION
@mtommasi @alainpreux @remigilleron 
Les 2 choses modifiées:
- enlevé le doublage des titres redondant 
- adopté une nouvelle syntaxe pour les listes et changements de paragraphes dans le Markdown à l'intérieur des questions GIFT

Avant pour simuler un changement de §, on allait simplement à la ligne et on utilisait l'extension python-markdown qui transformait tout retour simple à la ligne en <br/>. D'où les effets de bord quand on copiait-collait du texte avec des retours chariots à chaque ligne dans les paragraphes.

Maintenant, on applique la syntaxe Markdown officielle qui dit "avant le début d'une liste ou d'un nouveau §, il faut ajouter une ligne vide". Afin de ne pas casser la séparation des questions en GIFT par une ligne vide, on utilise donc "\n" [comme stipulé dans la doc](https://docs.moodle.org/30/en/GIFT_format#Format_symbols) pour indiquer une ligne vide. Exemple:

```
Téléchargez les deux fichiers suivants :
\n
- [representation1](media/representation1.odt)
- [representation2](media/representation2.odt).
\n
Ouvrez et parcourez ces deux fichiers. Sont-ils identiques ? Qu'est-ce qui les différencie ? Illustrez votre propos en citant des opérations qui seraient plus facilement réalisables avec l'un plutôt qu'avec l'autre et pourquoi.
```

Pour info également j'ai testé l'import de question GIFT dans Moodle et l'usage de \n passe très bien.
